### PR TITLE
Implement S3 archival and enable DecisionCard tests

### DIFF
--- a/apps/frontend/src/components/__tests__/decision-card.test.tsx
+++ b/apps/frontend/src/components/__tests__/decision-card.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-// Note: DecisionCard component not yet created locally, skipping for now
-// import { DecisionCard } from '@/components/ui/decision-card'
+import { DecisionCard } from '@/components/ui/decision-card'
 
 const mockProposal = {
   actionId: 'action-001',
@@ -31,8 +30,6 @@ const mockProposal = {
   expiresAt: new Date(Date.now() + 1000 * 60 * 60 * 48) // 48 hours from now
 }
 
-// TODO: Uncomment when DecisionCard component is available locally
-/*
 describe('DecisionCard', () => {
   it('displays proposal information correctly', () => {
     render(<DecisionCard {...mockProposal} />)
@@ -181,4 +178,3 @@ describe('DecisionCard', () => {
     expect(screen.getByRole('button', { name: /reject/i })).toBeInTheDocument()
   })
 })
-*/

--- a/packages/shared/src/generated/client/runtime/library.d.ts
+++ b/packages/shared/src/generated/client/runtime/library.d.ts
@@ -863,7 +863,7 @@ export declare namespace DMMF {
         delete = "delete",
         deleteMany = "deleteMany",
         groupBy = "groupBy",
-        count = "count",// TODO: count does not actually exist, why?
+        count = "count",
         aggregate = "aggregate",
         findRaw = "findRaw",
         aggregateRaw = "aggregateRaw"
@@ -2593,9 +2593,9 @@ declare type QueryMiddlewareParams = {
     model?: string;
     /** The action that is being handled */
     action: Action;
-    /** TODO what is this */
+    /** Location within the query for debugging */
     dataPath: string[];
-    /** TODO what is this */
+    /** Indicates if the query runs within a transaction */
     runInTransaction: boolean;
     args?: UserArgs_2;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1057,6 +1057,9 @@ importers:
 
   services/smm-architect:
     dependencies:
+      '@aws-sdk/client-s3':
+        specifier: ^3.445.0
+        version: 3.876.0
       '@google-cloud/kms':
         specifier: ^4.0.0
         version: 4.5.0

--- a/services/smm-architect/package.json
+++ b/services/smm-architect/package.json
@@ -30,7 +30,8 @@
     "uuid": "^9.0.0",
     "date-fns": "^2.30.0",
     "@sentry/node": "^7.99.0",
-    "@sentry/profiling-node": "^7.99.0"
+    "@sentry/profiling-node": "^7.99.0",
+    "@aws-sdk/client-s3": "^3.445.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",


### PR DESCRIPTION
## Summary
- implement S3 archival helper using AWS SDK and gzip
- enable DecisionCard component tests
- clean up leftover TODO comments

## Testing
- `pnpm --filter smm-architect-service test`
- `make test` *(fails: encore not found during build)*
- `make test-security` *(fails: missing RLS policies)*
- `pnpm test src/components/__tests__/decision-card.test.tsx` *(fails: Next.js cannot load TypeScript config)*

------
https://chatgpt.com/codex/tasks/task_e_68b96af1bbfc832b8838fb0d97ef7a5a
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Implemented S3 archival in the TTL job (gzip + S3 upload) to persist expired workspace data, and enabled DecisionCard tests. Also removed leftover TODO comments in generated types.

- **New Features**
  - TTLArchivalJob now compresses JSON and uploads to S3 using PutObjectCommand; path archived-workspaces/{workspace_id}/{timestamp}.json.gz; requires config.s3Bucket.
  - Enabled DecisionCard component tests by importing the component.

- **Dependencies**
  - Added @aws-sdk/client-s3.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatic archival of expired workspaces to cloud storage with compression and configurable retention.
  - Configurable batching and concurrency to improve archival throughput.

- Tests
  - Re-enabled DecisionCard test suite.

- Chores
  - Added cloud storage client dependency to support archival.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->