### PR TITLE
feat: add S3 archival and decision card tests

### DIFF
--- a/services/smm-architect/package.json
+++ b/services/smm-architect/package.json
@@ -25,6 +25,7 @@
     "encore.dev": "^1.0.0",
     "@google-cloud/kms": "^4.0.0",
     "node-vault": "^0.10.0",
+    "@aws-sdk/client-s3": "^3.445.0",
     "ajv": "^8.12.0",
     "winston": "^3.11.0",
     "uuid": "^9.0.0",

--- a/services/smm-architect/tests/decision-card.test.ts
+++ b/services/smm-architect/tests/decision-card.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from '@jest/globals';
+import { SimulationService } from '../src/services/simulation-service';
+import { WorkspaceContract, SimulationRequest } from '../src/types';
+
+const createWorkspace = (): WorkspaceContract => ({
+  workspaceId: 'ws-test-001',
+  tenantId: 'tenant-123',
+  createdBy: 'user-1',
+  createdAt: new Date().toISOString(),
+  lifecycle: 'active',
+  contractVersion: 'v1.0.0',
+  goals: [{ key: 'lead_gen', target: 100, unit: 'leads_per_month' }],
+  primaryChannels: ['linkedin'],
+  budget: {
+    currency: 'USD',
+    weeklyCap: 1000,
+    hardCap: 5000,
+    breakdown: {
+      paidAds: 400,
+      llmModelSpend: 200,
+      rendering: 200,
+      thirdPartyServices: 200
+    }
+  },
+  approvalPolicy: {
+    autoApproveReadinessThreshold: 0.8,
+    canaryInitialPct: 10,
+    canaryWatchWindowHours: 48,
+    manualApprovalForPaid: false,
+    legalManualApproval: false
+  },
+  riskProfile: 'medium',
+  dataRetention: { auditRetentionDays: 365 },
+  ttlHours: 24,
+  policyBundleRef: 'policy-v1',
+  policyBundleChecksum: 'checksum',
+  simulationConfig: { iterations: 5, randomSeed: 42, timeoutSeconds: 10 }
+});
+
+describe('DecisionCard generation', () => {
+  it('produces a sanitized decision card from simulation results', async () => {
+    const workspace = createWorkspace();
+    const service = new SimulationService();
+    const request: SimulationRequest = { targetChannels: ['linkedin'] };
+
+    const response = await service.simulate(workspace, request);
+    const card = response.decisionCard;
+
+    expect(card.workspaceId).toBe(workspace.workspaceId);
+    expect(card.readiness_score).toBeGreaterThan(0);
+    expect(card.primary_action.label).toBeDefined();
+    expect(JSON.stringify(card).toLowerCase()).not.toContain('credentials');
+  });
+});


### PR DESCRIPTION
## Summary
- implement secure S3 archival for TTL job with server-side encryption
- add DecisionCard generation test to validate sanitized output
- include AWS S3 client dependency for archival

## Testing
- `npm test` *(fails: Module ts-jest should have "jest-preset.js" or "jest-preset.json" file at the root)*

------
https://chatgpt.com/codex/tasks/task_e_68b96af694fc832b83c3ef456d661285
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds secure S3 archival to the TTL job and a DecisionCard test to ensure sanitized output. Archives compressed JSON to S3 with AES-256 server-side encryption, gated by config flags.

- New Features
  - Archive TTL job output to S3 (gzip) with AES256 server-side encryption; returns an s3:// URI.
  - Config-driven via archiveToS3 and s3Bucket; uses AWS_REGION (defaults to us-east-1); logs and rethrows on failure.
  - DecisionCard test verifies readiness score, primary action, and no leaked credentials.

- Dependencies
  - Added @aws-sdk/client-s3 (^3.445.0).

<!-- End of auto-generated description by cubic. -->

