### PR TITLE
Compress TTL archival payloads and upload to S3

### DIFF
--- a/services/smm-architect/package.json
+++ b/services/smm-architect/package.json
@@ -30,7 +30,8 @@
     "uuid": "^9.0.0",
     "date-fns": "^2.30.0",
     "@sentry/node": "^7.99.0",
-    "@sentry/profiling-node": "^7.99.0"
+    "@sentry/profiling-node": "^7.99.0",
+    "@aws-sdk/client-s3": "^3.490.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/services/smm-architect/src/utils/logger.ts
+++ b/services/smm-architect/src/utils/logger.ts
@@ -1,0 +1,1 @@
+export { logger } from '@smm-architect/shared/utils/logger';

--- a/services/smm-architect/tests/ttl-archival-job.test.ts
+++ b/services/smm-architect/tests/ttl-archival-job.test.ts
@@ -1,0 +1,51 @@
+import { gunzipSync } from 'zlib';
+
+jest.mock('../src/utils/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+jest.mock('../../shared/database/client', () => ({
+  DatabaseClient: jest.fn(),
+}));
+
+const sendMock = jest.fn().mockResolvedValue({});
+
+jest.mock('@aws-sdk/client-s3', () => ({
+  S3Client: jest.fn(() => ({
+    send: sendMock,
+  })),
+  PutObjectCommand: jest.fn((input) => ({ input })),
+}));
+
+import { TTLArchivalJob } from '../src/jobs/ttl-archival-job';
+
+describe('archiveToS3', () => {
+  it('uploads compressed payload and returns s3 path', async () => {
+    const job = new TTLArchivalJob({} as any, {
+      dryRun: false,
+      batchSize: 1,
+      maxConcurrency: 1,
+      archiveToS3: true,
+      s3Bucket: 'test-bucket',
+      retentionDays: 1,
+    });
+
+    const data = { foo: 'bar' };
+    const result = await (job as any).archiveToS3('workspace-123', data);
+
+    expect(sendMock).toHaveBeenCalledTimes(1);
+    const command = sendMock.mock.calls[0][0];
+    expect(command.input.Bucket).toBe('test-bucket');
+    expect(command.input.Key).toMatch(/^archived-workspaces\/workspace-123\/\d+\.json\.gz$/);
+
+    const body = command.input.Body as Buffer;
+    const decompressed = JSON.parse(gunzipSync(body).toString());
+    expect(decompressed).toEqual(data);
+    expect(result).toBe(`s3://test-bucket/${command.input.Key}`);
+  });
+});


### PR DESCRIPTION
## Summary
- Compress workspace payloads with gzip and upload to S3 in `TTLArchivalJob`
- Add AWS S3 SDK dependency and unit tests for S3 archival

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b96f877a24832bb64a79d1ff8f1040