### PR TITLE
feat: add devcontainer and smoke test

### DIFF
--- a/.github/workflows/devcontainer-smoke.yml
+++ b/.github/workflows/devcontainer-smoke.yml
@@ -1,0 +1,16 @@
+name: Dev Container Smoke Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build dev container
+        run: docker build -t smm-architect-dev -f tools/devcontainer/Dockerfile .
+      - name: Run pnpm install
+        run: docker run --rm -v ${{ github.workspace }}:/workspace -w /workspace smm-architect-dev pnpm install --ignore-scripts

--- a/README.md
+++ b/README.md
@@ -28,6 +28,18 @@ SMM Architect is an **enterprise-ready platform** that enables organizations to 
 - **Real-Time Monitoring**: Prometheus metrics, Grafana dashboards, Sentry error tracking
 - **Infrastructure as Code**: Pulumi templates for automated AWS deployment
 
+## 🧰 Development Container
+
+A preconfigured Docker development container is available in `tools/devcontainer/`.
+Build and start it with:
+
+```bash
+docker build -t smm-architect-dev -f tools/devcontainer/Dockerfile .
+docker run --rm -it -v "$(pwd)":/workspace smm-architect-dev
+```
+
+See [docs/development.md](docs/development.md) for more details.
+
 ## 🏢 Architecture
 
 ### Monorepo Structure

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,29 @@
+# SMM Architect Development Guide
+
+This guide describes how to set up a local development environment using the provided Docker-based dev container.
+
+## Prerequisites
+
+- Docker 20+
+- Git
+
+## Build the Dev Container
+
+```bash
+docker build -t smm-architect-dev -f tools/devcontainer/Dockerfile .
+```
+
+## Start an Interactive Shell
+
+Run the container and mount the repository:
+
+```bash
+docker run --rm -it -v "$(pwd)":/workspace smm-architect-dev
+```
+
+The container includes Node.js, pnpm, Python `distutils`, and common build tools. On startup it runs `pnpm install` to install project dependencies.
+
+## Using VS Code Dev Containers
+
+If you use VS Code, open the repository and choose **Dev Containers: Reopen in Container**. The configuration in `tools/devcontainer/devcontainer.json` will be used automatically.
+

--- a/tools/devcontainer/Dockerfile
+++ b/tools/devcontainer/Dockerfile
@@ -1,0 +1,10 @@
+FROM mcr.microsoft.com/devcontainers/javascript-node:18
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 \
+    python3-distutils \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN corepack enable
+

--- a/tools/devcontainer/devcontainer.json
+++ b/tools/devcontainer/devcontainer.json
@@ -1,0 +1,14 @@
+{
+  "name": "SMM Architect Dev Container",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": "../.."
+  },
+  "postCreateCommand": "pnpm install",
+  "customizations": {
+    "vscode": {
+      "settings": {},
+      "extensions": []
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Docker-based dev container with build tools and pnpm bootstrap
- document usage in README and development guide
- add CI workflow to build container and run pnpm install as smoke test

## Testing
- `make test` *(fails: npm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bab53972fc832bb393d6634482dd21