### PR TITLE
Add RDS snapshot backups and restoration runbook

### DIFF
--- a/docs/rds-snapshot-restore-runbook.md
+++ b/docs/rds-snapshot-restore-runbook.md
@@ -1,0 +1,50 @@
+# RDS Snapshot Restoration Runbook
+
+This runbook describes how to restore the production PostgreSQL database from the most recent snapshot and resume service operation.
+
+## Prerequisites
+- AWS CLI configured with sufficient permissions
+- Database endpoint and credentials for the restored instance
+- Access to the SMM Architect infrastructure repository
+
+## Steps
+1. **Locate the latest snapshot**
+   ```bash
+   aws rds describe-db-snapshots \
+     --db-instance-identifier smm-architect \
+     --snapshot-type automated \
+     --query 'reverse(sort_by(DBSnapshots, &SnapshotCreateTime))[0].DBSnapshotIdentifier'
+   ```
+2. **Restore snapshot to a new instance**
+   ```bash
+   aws rds restore-db-instance-from-db-snapshot \
+     --db-instance-identifier smm-architect-restore \
+     --db-snapshot-identifier <SNAPSHOT_ID> \
+     --db-instance-class db.t3.micro
+   ```
+3. **Apply security group and subnet settings**
+   ```bash
+   aws rds modify-db-instance \
+     --db-instance-identifier smm-architect-restore \
+     --vpc-security-group-ids <SG_ID> \
+     --db-subnet-group-name <SUBNET_GROUP>
+   ```
+4. **Update application configuration**
+   - Point `DATABASE_URL` to the new instance endpoint
+   - Redeploy services using `pulumi up` or appropriate deployment tool
+5. **Validate restoration**
+   ```bash
+   psql $DATABASE_URL -c "SELECT 1;"
+   ```
+6. **Promote restored instance**
+   - Optional: rename instances or update DNS to route traffic to the restored database
+   - Decommission the old instance once validated
+
+## Verification Checklist
+- [ ] Snapshot restored successfully
+- [ ] Application connected to restored database
+- [ ] Data integrity verified
+- [ ] Old instance cleaned up
+
+---
+*Last Updated: 2025-09-05*


### PR DESCRIPTION
## Summary
- schedule and export RDS snapshots to S3 with backup plan and export task
- document RDS snapshot restoration steps
- validate recent snapshots in production readiness script

## Testing
- `pre-commit run --files infrastructure/base/main/index.ts tools/scripts/production-readiness-validation.sh docs/rds-snapshot-restore-runbook.md` *(failed: command not found)*
- `npm test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bab533bf70832bb5d6bc32fa57e140
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds scheduled RDS snapshots and S3 exports for the PostgreSQL database, plus a restore runbook and a readiness check for recent backups. Improves disaster recovery with daily backups (30-day retention) and clear restore steps.

- New Features
  - Daily AWS Backup plan at 03:00 UTC with 30-day retention for the RDS instance; copyTagsToSnapshot enabled.
  - Snapshot export to S3: versioned bucket (SSE-S3), KMS key, IAM role, manual RDS snapshot, and export task.
  - Production readiness script validates a successful automated RDS snapshot within the last 24 hours.
  - Runbook added with step-by-step restore and a verification checklist.

- Migration
  - Ensure permissions for Backup, RDS export, S3, and KMS; allow the export role to use the KMS key if required.
  - If your DB identifier differs, set DB_INSTANCE_IDENTIFIER for the readiness script.

<!-- End of auto-generated description by cubic. -->

