### PR TITLE
feat: add gcp logging support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@genkit-ai/mcp": "^1.17.1",
+        "@google-cloud/logging": "^11.2.0",
         "@sentry/node": "^7.99.0",
         "@sentry/profiling-node": "^7.99.0",
         "@types/js-yaml": "^4.0.9",
@@ -2283,8 +2284,6 @@
       "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-5.0.2.tgz",
       "integrity": "sha512-V7bmBKYQyu0eVG2BFejuUjlBt+zrya6vtsKdY+JxMM/dNntPF41vZ9+LhOshEUH01zOHEqBSvI7Dad7ZS6aUeA==",
       "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@google-cloud/projectify": "^4.0.0",
         "@google-cloud/promisify": "^4.0.0",
@@ -2305,8 +2304,6 @@
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
       "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "end-of-stream": "^1.4.1",
         "inherits": "^2.0.3",
@@ -2337,8 +2334,6 @@
       "resolved": "https://registry.npmjs.org/@google-cloud/logging/-/logging-11.2.0.tgz",
       "integrity": "sha512-Ma94jvuoMpbgNniwtelOt8w82hxK62FuOXZonEv0Hyk3B+/YVuLG/SWNyY9yMso/RXnPEc1fP2qo9kDrjf/b2w==",
       "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@google-cloud/common": "^5.0.0",
         "@google-cloud/paginator": "^5.0.0",
@@ -2386,8 +2381,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2397,8 +2390,6 @@
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
       "integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "is-obj": "^2.0.0"
       },
@@ -2414,8 +2405,6 @@
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
       "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "end-of-stream": "^1.4.1",
         "inherits": "^2.0.3",
@@ -2428,8 +2417,6 @@
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
       "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2439,8 +2426,6 @@
       "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-2.0.1.tgz",
       "integrity": "sha512-m7KOje7jZxrmutanlkS1daj1dS6z6BgslzOXmcSEpIlCxM3VJH7lG5QLeck/6hgF6F4crFf01UtQmNsJfweTAw==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "duplexify": "^4.1.1",
         "inherits": "^2.0.3",
@@ -2516,8 +2501,6 @@
       "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-5.0.2.tgz",
       "integrity": "sha512-DJS3s0OVH4zFDB1PzjxAsHqJT6sKVbRwwML0ZBP9PbU7Yebtu/7SWMRzvO2J3nUi9pRNITCfu4LJeooM2w4pjg==",
       "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "arrify": "^2.0.0",
         "extend": "^3.0.2"
@@ -2542,8 +2525,6 @@
       "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-4.0.0.tgz",
       "integrity": "sha512-MmaX6HeSvyPbWGwFq7mXdo0uQZLGBYCwziiLIGq5JVX+/bdI3SAq6bP98trV5eTWfLuvsMcIC1YJOF2vfteLFA==",
       "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -2553,8 +2534,6 @@
       "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-4.1.0.tgz",
       "integrity": "sha512-G/FQx5cE/+DqBbOpA5jKsegGwdPniU6PuIEMt+qxWgFxvxuFOzVmp6zYchtYuwAWV5/8Dgs0yAmjvNZv3uXLQg==",
       "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7432,6 +7411,7 @@
     },
     "node_modules/@sentry/profiling-node": {
       "version": "7.120.4",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "detect-libc": "^2.0.2",
@@ -8127,8 +8107,6 @@
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -8239,9 +8217,7 @@
     },
     "node_modules/@types/caseless": {
       "version": "0.12.5",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/connect": {
       "version": "3.4.38",
@@ -8362,9 +8338,7 @@
     },
     "node_modules/@types/long": {
       "version": "4.0.2",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/memcached": {
       "version": "2.2.10",
@@ -8444,8 +8418,6 @@
     "node_modules/@types/request": {
       "version": "2.48.13",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@types/caseless": "*",
         "@types/node": "*",
@@ -8456,8 +8428,6 @@
     "node_modules/@types/request/node_modules/form-data": {
       "version": "2.5.5",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -8526,9 +8496,7 @@
     },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.5",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/triple-beam": {
       "version": "1.3.5",
@@ -8791,8 +8759,6 @@
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "event-target-shim": "^5.0.0"
       },
@@ -9079,8 +9045,6 @@
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
       "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -11111,8 +11075,7 @@
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ejs": {
       "version": "3.1.10",
@@ -11562,8 +11525,6 @@
     "node_modules/event-target-shim": {
       "version": "5.0.1",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -11577,8 +11538,6 @@
       "resolved": "https://registry.npmjs.org/eventid/-/eventid-2.0.1.tgz",
       "integrity": "sha512-sPNTqiMokAvV048P2c9+foqVJzk49o6d4e0D/sq5jog3pw+4kBgyR0gaM1FM7Mx6Kzd9dztesh9oYz1LWWOpzw==",
       "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "uuid": "^8.0.0"
       },
@@ -11591,8 +11550,6 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -12334,8 +12291,6 @@
     "node_modules/gaxios": {
       "version": "6.7.1",
       "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "extend": "^3.0.2",
         "https-proxy-agent": "^7.0.1",
@@ -12350,8 +12305,6 @@
     "node_modules/gaxios/node_modules/https-proxy-agent": {
       "version": "7.0.6",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "4"
@@ -12363,8 +12316,6 @@
     "node_modules/gcp-metadata": {
       "version": "6.1.1",
       "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "gaxios": "^6.1.1",
         "google-logging-utils": "^0.0.2",
@@ -12581,8 +12532,6 @@
     "node_modules/google-auth-library": {
       "version": "9.15.1",
       "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
@@ -12598,8 +12547,6 @@
     "node_modules/google-gax": {
       "version": "4.6.1",
       "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@grpc/grpc-js": "^1.10.9",
         "@grpc/proto-loader": "^0.7.13",
@@ -12621,8 +12568,6 @@
     "node_modules/google-gax/node_modules/duplexify": {
       "version": "4.1.3",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "end-of-stream": "^1.4.1",
         "inherits": "^2.0.3",
@@ -12633,8 +12578,6 @@
     "node_modules/google-logging-utils": {
       "version": "0.0.2",
       "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -12718,8 +12661,6 @@
     "node_modules/gtoken": {
       "version": "7.1.0",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "gaxios": "^6.0.0",
         "jws": "^4.0.0"
@@ -12850,9 +12791,7 @@
           "url": "https://patreon.com/mdevils"
         }
       ],
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -12906,8 +12845,6 @@
     "node_modules/http-proxy-agent": {
       "version": "5.0.0",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@tootallnate/once": "2",
         "agent-base": "6",
@@ -12920,8 +12857,6 @@
     "node_modules/http-proxy-agent/node_modules/agent-base": {
       "version": "6.0.2",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "debug": "4"
       },
@@ -13311,7 +13246,6 @@
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -14244,8 +14178,6 @@
     "node_modules/jws": {
       "version": "4.0.0",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "jwa": "^2.0.0",
         "safe-buffer": "^5.0.1"
@@ -14254,8 +14186,6 @@
     "node_modules/jws/node_modules/jwa": {
       "version": "2.0.1",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "buffer-equal-constant-time": "^1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
@@ -14911,8 +14841,6 @@
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -14930,21 +14858,15 @@
     },
     "node_modules/node-fetch/node_modules/tr46": {
       "version": "0.0.3",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/node-fetch/node_modules/webidl-conversions": {
       "version": "3.0.1",
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/node-fetch/node_modules/whatwg-url": {
       "version": "5.0.0",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -15027,8 +14949,6 @@
     "node_modules/object-hash": {
       "version": "3.0.0",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 6"
       }
@@ -15047,7 +14967,6 @@
     "node_modules/on-finished": {
       "version": "2.4.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ee-first": "1.1.1"
       },
@@ -15663,8 +15582,6 @@
     "node_modules/proto3-json-serializer": {
       "version": "2.0.2",
       "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "protobufjs": "^7.2.5"
       },
@@ -16014,8 +15931,6 @@
     "node_modules/retry-request": {
       "version": "7.0.2",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@types/request": "^2.48.8",
         "extend": "^3.0.2",
@@ -16547,17 +16462,13 @@
     "node_modules/stream-events": {
       "version": "1.0.5",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "stubs": "^3.0.0"
       }
     },
     "node_modules/stream-shift": {
       "version": "1.0.3",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -16691,9 +16602,7 @@
     },
     "node_modules/stubs": {
       "version": "3.0.0",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/stylus-lookup": {
       "version": "5.0.1",
@@ -16766,8 +16675,6 @@
     "node_modules/teeny-request": {
       "version": "9.0.0",
       "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "http-proxy-agent": "^5.0.0",
         "https-proxy-agent": "^5.0.0",
@@ -17177,6 +17084,7 @@
     },
     "node_modules/unix-dgram": {
       "version": "2.0.7",
+      "hasInstallScript": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   },
   "dependencies": {
     "@genkit-ai/mcp": "^1.17.1",
+    "@google-cloud/logging": "^11.2.0",
     "@sentry/node": "^7.99.0",
     "@sentry/profiling-node": "^7.99.0",
     "@types/js-yaml": "^4.0.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ importers:
       '@genkit-ai/mcp':
         specifier: ^1.17.1
         version: 1.17.1(@modelcontextprotocol/sdk@1.17.4)(genkit@1.17.1)
+      '@google-cloud/logging':
+        specifier: ^11.2.0
+        version: 11.2.0
       '@sentry/node':
         specifier: ^7.99.0
         version: 7.120.4


### PR DESCRIPTION
## Summary
- integrate Google Cloud Logging for audit log streaming
- add GCP logging dependency

## Testing
- `make test` *(fails: smm-architect-service build encore not found)*
- `make test-security` *(fails: missing RLS policies)*

------
https://chatgpt.com/codex/tasks/task_e_68b96f8a5f7c832b8ac068dc9db53b4c
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add Google Cloud Logging support for audit log streaming. Audit events can now be sent to a GCP log with retries and clear auth error handling.

- **New Features**
  - Implemented sendToGCPLogging using @google-cloud/logging.
  - Retries on 429/500/502/503/504 with incremental backoff; surfaces 401/403 auth failures.
  - Writes entries to the specified logName with resource type "global".

- **Migration**
  - Configure the SIEM destination with: project, logName, and either keyFilename or credentials.
  - Ensure the writer has roles/logging.logWriter on the target project.

<!-- End of auto-generated description by cubic. -->

