### PR TITLE
feat: add devcontainer and smoke-test workflow

### DIFF
--- a/.github/workflows/devcontainer-smoke.yml
+++ b/.github/workflows/devcontainer-smoke.yml
@@ -1,0 +1,19 @@
+name: Devcontainer Smoke Test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Build dev container
+        run: docker build -f tools/devcontainer/Dockerfile -t smm-architect-dev .
+
+      - name: Run pnpm install
+        run: docker run --rm -v $PWD:/workspace -w /workspace smm-architect-dev pnpm install --frozen-lockfile

--- a/README.md
+++ b/README.md
@@ -434,6 +434,23 @@ See `examples/workspace-contract.icblabs.json` for a complete example workspace 
 - Agent failure rates
 - Security incidents
 
+## 💻 Development Environment
+
+A Docker-based development container is provided for a consistent build setup.
+
+```bash
+docker build -f tools/devcontainer/Dockerfile -t smm-architect-dev .
+docker run --rm -it -v $(pwd):/workspace smm-architect-dev
+```
+
+Inside the container, install dependencies:
+
+```bash
+pnpm install
+```
+
+See [docs/development.md](docs/development.md) for more details.
+
 ## 🤝 Contributing
 
 1. **Fork the repository**

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,25 @@
+# Development Guide
+
+This repository includes a Docker-based development container that provides all required system dependencies.
+
+## Using the Dev Container
+
+1. **Build the container:**
+
+```bash
+docker build -f tools/devcontainer/Dockerfile -t smm-architect-dev .
+```
+
+2. **Start the container:**
+
+```bash
+docker run --rm -it -v $(pwd):/workspace smm-architect-dev
+```
+
+3. **Install dependencies inside the container:**
+
+```bash
+pnpm install
+```
+
+The container includes Python distutils and common build tools so native modules compile correctly. It can also be opened directly with compatible editors such as VS Code via `tools/devcontainer/devcontainer.json`.

--- a/tools/devcontainer/Dockerfile
+++ b/tools/devcontainer/Dockerfile
@@ -1,0 +1,19 @@
+# Devcontainer for SMM Architect
+FROM node:20-bullseye
+
+# Install Python distutils and build tools
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        python3 \
+        python3-distutils \
+        python3-pip \
+        build-essential \
+        git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Enable corepack for pnpm
+RUN corepack enable
+
+WORKDIR /workspace
+
+CMD ["bash"]

--- a/tools/devcontainer/devcontainer.json
+++ b/tools/devcontainer/devcontainer.json
@@ -1,0 +1,16 @@
+{
+  "name": "smm-architect-dev",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": "../.."
+  },
+  "workspaceFolder": "/workspace",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Docker-based devcontainer with Python distutils and build tools
- document devcontainer usage in README and docs
- create CI job to build container and run pnpm install

## Testing
- `pnpm install` *(fails: ModuleNotFoundError: No module named 'distutils')*
- `npm test` *(fails: turbo: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e2ed73e8832bb6ff445a07722645