### PR TITLE
Add cert-manager Helm chart with Let's Encrypt issuers

### DIFF
--- a/docs/production-readiness-guide.md
+++ b/docs/production-readiness-guide.md
@@ -366,6 +366,20 @@ curl -f $API_ENDPOINT/health
 
 ## Maintenance and Monitoring
 
+### Certificate Renewal Procedures
+cert-manager automatically renews TLS certificates 30 days before expiration. Use the following commands to monitor and force renewal when needed:
+
+```bash
+# Check certificate status
+kubectl get certificate -n smm-architect
+
+# Manually trigger a renewal
+kubectl cert-manager renew smm-architect-cert -n smm-architect
+
+# Verify new expiration date
+kubectl get certificate smm-architect-cert -n smm-architect -o jsonpath='{.status.notAfter}'
+```
+
 ### Regular Maintenance Tasks
 
 #### Daily

--- a/infrastructure/kubernetes/20-istio-gateway.yaml
+++ b/infrastructure/kubernetes/20-istio-gateway.yaml
@@ -24,7 +24,7 @@ spec:
       protocol: HTTPS
     tls:
       mode: SIMPLE
-      credentialName: smm-architect-tls
+      credentialName: smm-architect-tls # managed by cert-manager
     hosts:
     - api.smm-architect.com
     - toolhub.smm-architect.com

--- a/infrastructure/kubernetes/helm/cert-manager/Chart.yaml
+++ b/infrastructure/kubernetes/helm/cert-manager/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: cert-manager
+description: Helm chart to install cert-manager and configure Let's Encrypt issuers
+version: 0.1.0
+appVersion: "1.14.2"
+type: application
+dependencies:
+  - name: cert-manager
+    version: "v1.14.2"
+    repository: "https://charts.jetstack.io"

--- a/infrastructure/kubernetes/helm/cert-manager/templates/certificate.yaml
+++ b/infrastructure/kubernetes/helm/cert-manager/templates/certificate.yaml
@@ -1,0 +1,14 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: smm-architect-cert
+  namespace: smm-architect
+spec:
+  secretName: smm-architect-tls
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+    - api.smm-architect.com
+    - toolhub.smm-architect.com
+    - app.smm-architect.com

--- a/infrastructure/kubernetes/helm/cert-manager/templates/clusterissuer-production.yaml
+++ b/infrastructure/kubernetes/helm/cert-manager/templates/clusterissuer-production.yaml
@@ -1,0 +1,14 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-production
+spec:
+  acme:
+    email: {{ .Values.letsencrypt.email }}
+    server: {{ .Values.letsencrypt.production.server }}
+    privateKeySecretRef:
+      name: letsencrypt-production
+    solvers:
+      - http01:
+          ingress:
+            class: istio

--- a/infrastructure/kubernetes/helm/cert-manager/templates/clusterissuer-staging.yaml
+++ b/infrastructure/kubernetes/helm/cert-manager/templates/clusterissuer-staging.yaml
@@ -1,0 +1,14 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging
+spec:
+  acme:
+    email: {{ .Values.letsencrypt.email }}
+    server: {{ .Values.letsencrypt.staging.server }}
+    privateKeySecretRef:
+      name: letsencrypt-staging
+    solvers:
+      - http01:
+          ingress:
+            class: istio

--- a/infrastructure/kubernetes/helm/cert-manager/values.yaml
+++ b/infrastructure/kubernetes/helm/cert-manager/values.yaml
@@ -1,0 +1,9 @@
+cert-manager:
+  installCRDs: true
+
+letsencrypt:
+  email: admin@example.com
+  staging:
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+  production:
+    server: https://acme-v02.api.letsencrypt.org/directory


### PR DESCRIPTION
## Summary
- add cert-manager helm chart with Let’s Encrypt staging and production issuers
- update Istio gateway to reference cert-manager managed TLS secret
- document TLS certificate renewal using cert-manager

## Testing
- `make test` *(fails: sh: 1: turbo: not found)*
- `make test-security` *(fails: 54 RLS violations)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e2ec2254832b9801d8f7543c48b4