### PR TITLE
feat: automate RDS snapshot scheduling

### DIFF
--- a/docs/rds-restoration-runbook.md
+++ b/docs/rds-restoration-runbook.md
@@ -1,0 +1,43 @@
+# RDS Snapshot Restoration Runbook
+
+This runbook describes how to restore the production database from the most recent automated snapshot.
+
+## Prerequisites
+- AWS CLI configured with access to the target account
+- IAM permissions for RDS restore and S3 access
+- Identifier of the RDS instance to restore
+
+## 1. Locate the Latest Snapshot
+```bash
+DB_INSTANCE_ID="smm-postgres"
+LATEST_SNAPSHOT=$(aws rds describe-db-snapshots \
+  --db-instance-identifier "$DB_INSTANCE_ID" \
+  --snapshot-type automated \
+  --query 'max_by(DBSnapshots,&SnapshotCreateTime).DBSnapshotIdentifier' \
+  --output text)
+```
+
+## 2. Restore the Snapshot
+```bash
+aws rds restore-db-instance-from-db-snapshot \
+  --db-instance-identifier "${DB_INSTANCE_ID}-restore" \
+  --db-snapshot-identifier "$LATEST_SNAPSHOT" \
+  --db-subnet-group-name smm-db-subnet-group \
+  --no-publicly-accessible
+```
+
+## 3. Promote Restored Instance
+1. Wait for the restored instance to reach the `available` status.
+2. Update application configuration with the new endpoint.
+3. Run database migrations as needed.
+
+## 4. Cleanup
+- Once verified, decommission the old instance if required.
+- Remove temporary restore instances to avoid charges.
+
+## Verification
+```bash
+aws rds describe-db-instances --db-instance-identifier "${DB_INSTANCE_ID}-restore" \
+  --query 'DBInstances[0].DBInstanceStatus'
+```
+Ensure the status returns `available` before resuming normal operations.


### PR DESCRIPTION
## Summary
- schedule daily RDS snapshots and export latest snapshot to S3
- add runbook for restoring database from snapshots
- verify recent RDS backups in production readiness checks

## Testing
- `make test` *(fails: smm-architect-service#build)*
- `make test-security` *(fails: RLS violations in migrations)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e2e98e84832ba1a83c4c0bf9933b
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Automates daily RDS snapshots and exports the latest snapshot to S3 to strengthen disaster recovery. Adds a restoration runbook and a production readiness check that ensures a fresh automated snapshot exists.

- **New Features**
  - Daily RDS snapshots at 02:00 UTC with 7-day retention and tag copying; schedule associated with the DB instance.
  - Export of the most recent snapshot to S3 via a dedicated IAM role/policy.
  - Restoration runbook added, plus a readiness check that verifies an automated snapshot within 24h (configurable via DB_INSTANCE_IDENTIFIER).

<!-- End of auto-generated description by cubic. -->

