### PR TITLE
feat: enable prisma migrations

### DIFF
--- a/packages/shared/jest.config.js
+++ b/packages/shared/jest.config.js
@@ -1,0 +1,12 @@
+const path = require('path');
+
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/tests/**/*.test.ts'],
+  globals: {
+    'ts-jest': {
+      tsconfig: path.join(__dirname, 'tsconfig.test.json')
+    }
+  }
+};

--- a/packages/shared/tests/migration.test.ts
+++ b/packages/shared/tests/migration.test.ts
@@ -1,0 +1,46 @@
+import { execSync } from 'child_process';
+
+jest.mock('child_process', () => ({
+  execSync: jest.fn()
+}));
+
+jest.mock('@prisma/client', () => ({
+  PrismaClient: jest.fn().mockImplementation(() => ({
+    $queryRaw: jest.fn(),
+    $executeRaw: jest.fn(),
+    $disconnect: jest.fn(),
+    $use: jest.fn()
+  }))
+}));
+
+import { DatabaseMigration } from '../src/database/client';
+
+const connectionString = 'postgresql://user:pass@localhost:5432/test';
+
+describe('DatabaseMigration', () => {
+  beforeEach(() => {
+    (execSync as jest.Mock).mockReset();
+  });
+
+  test('migrate executes prisma migrate deploy', async () => {
+    const migration = new DatabaseMigration({ connectionString });
+    await migration.migrate();
+    expect(execSync).toHaveBeenCalledWith(
+      expect.stringContaining('prisma migrate deploy'),
+      expect.objectContaining({
+        env: expect.objectContaining({ DATABASE_URL: connectionString })
+      })
+    );
+  });
+
+  test('reset executes prisma migrate reset', async () => {
+    const migration = new DatabaseMigration({ connectionString });
+    await migration.reset();
+    expect(execSync).toHaveBeenCalledWith(
+      expect.stringContaining('prisma migrate reset'),
+      expect.objectContaining({
+        env: expect.objectContaining({ DATABASE_URL: connectionString })
+      })
+    );
+  });
+});

--- a/packages/shared/tsconfig.test.json
+++ b/packages/shared/tsconfig.test.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../build-config/typescript/tsconfig.backend.json",
+  "include": ["src/**/*.ts", "tests/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- enable Prisma CLI execution for database migrations and resets
- add Jest setup and tests covering migration/reset logic

## Testing
- `node node_modules/jest/bin/jest.js packages/shared/tests/migration.test.ts --config packages/shared/jest.config.js`
- `pre-commit run --files packages/shared/src/database/client.ts packages/shared/jest.config.js packages/shared/tests/migration.test.ts packages/shared/database/migrations/.gitkeep packages/shared/tsconfig.test.json` *(fails: Type tag 'typescript' is not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_68b972d1b4cc832b8ecf159b861da62e