### PR TITLE
feat: compute compliance summary from db

### DIFF
--- a/services/agents/tests/legal-agent-compliance-summary.test.ts
+++ b/services/agents/tests/legal-agent-compliance-summary.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from '@jest/globals';
+import LegalAgent, { LegalConfig } from '../legal-agent/LegalAgent';
+import type { Logger } from 'winston';
+
+describe('LegalAgent.getComplianceSummary', () => {
+  it('calculates totals from compliance records', async () => {
+    const mockDb = {
+      complianceCheck: {
+        findMany: jest.fn().mockResolvedValue([
+          { status: 'compliant', score: 90, region: 'US', violations: [] },
+          {
+            status: 'non_compliant',
+            score: 60,
+            region: 'EU',
+            violations: [{ ruleId: 'GDPR Data Processing Disclosure' }]
+          },
+          {
+            status: 'needs_review',
+            score: 70,
+            region: 'US',
+            violations: [{ ruleId: 'Promotional Content Disclosure' }]
+          },
+          {
+            status: 'non_compliant',
+            score: 55,
+            region: 'EU',
+            violations: [
+              { ruleId: 'GDPR Data Processing Disclosure' },
+              { ruleId: 'Accessibility Alt Text' }
+            ]
+          }
+        ])
+      }
+    } as unknown as any;
+
+    const mockLogger = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn()
+    } as unknown as Logger;
+
+    const config: LegalConfig = {
+      enabledRegions: ['US', 'EU'],
+      defaultRegion: 'US',
+      strictMode: false,
+      autoBlockingEnabled: false,
+      complianceThreshold: 80,
+      regulationCheckTimeout: 5000
+    };
+
+    const agent = new LegalAgent(config, mockLogger, mockDb);
+
+    const summary = await agent.getComplianceSummary('ws-1');
+
+    expect(mockDb.complianceCheck.findMany).toHaveBeenCalledWith({
+      where: { workspaceId: 'ws-1' },
+      select: {
+        status: true,
+        score: true,
+        region: true,
+        violations: { select: { ruleId: true } }
+      }
+    });
+
+    expect(summary).toEqual({
+      overallScore: 69,
+      totalChecks: 4,
+      compliantContent: 1,
+      nonCompliantContent: 2,
+      pendingReview: 1,
+      commonViolations: [
+        { rule: 'GDPR Data Processing Disclosure', count: 2 },
+        { rule: 'Promotional Content Disclosure', count: 1 },
+        { rule: 'Accessibility Alt Text', count: 1 }
+      ],
+      regionBreakdown: { US: 80, EU: 58 }
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary
- query compliance records from database in LegalAgent
- derive compliance summary metrics from query results
- add unit test validating compliance totals using mocked database

## Testing
- `pre-commit run --files services/agents/legal-agent/LegalAgent.ts services/agents/tests/legal-agent-compliance-summary.test.ts` *(fails: command not found)*
- `node node_modules/.pnpm/jest@29.7.0_@types+node@20.19.11_ts-node@10.9.2/node_modules/jest/bin/jest.js --rootDir services/agents --setupFilesAfterEnv=../../tests/setup.ts -- tests/legal-agent-compliance-summary.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b972e26a54832b901932f83bf844ca
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Compute workspace compliance summaries from the database, replacing mock data with real metrics and region averages. Adds Prisma-backed querying with a safe fallback and unit tests.

- **New Features**
  - Query complianceCheck via Prisma in LegalAgent, with optional db injection and runtime fallback.
  - Derive metrics: overall score (avg), totals by status, top violations, per-region average scores.
  - Log and throw on query failures.
  - Add unit test covering aggregation using a mocked DB.

<!-- End of auto-generated description by cubic. -->

