### PR TITLE
feat: fetch workspace data via HTTP in simulator

### DIFF
--- a/services/simulator/jest.config.js
+++ b/services/simulator/jest.config.js
@@ -1,0 +1,15 @@
+const backendConfig = require('../../packages/build-config/jest/jest.config.backend.js');
+
+module.exports = {
+  ...backendConfig,
+  displayName: 'Simulator Service',
+  testMatch: ['<rootDir>/test/**/*.test.ts'],
+  setupFilesAfterEnv: [],
+  collectCoverageFrom: [
+    'src/**/*.{ts}',
+    '!src/**/*.d.ts',
+    '!src/**/*.test.{ts}',
+    '!src/**/*.spec.{ts}',
+    '!src/types/**/*'
+  ]
+};

--- a/services/simulator/test/server.test.ts
+++ b/services/simulator/test/server.test.ts
@@ -1,0 +1,69 @@
+import request from 'supertest';
+import axios from 'axios';
+import app from '../src/server';
+import { MonteCarloEngine } from '../src/services/monte-carlo-engine';
+import { WorkspaceContext } from '../src/types';
+
+jest.mock('axios');
+jest.mock('../src/config/sentry', () => ({}));
+
+describe('Simulator server workspace fetching', () => {
+  const mockWorkspace: WorkspaceContext = {
+    workspaceId: 'ws-test',
+    goals: [{ key: 'lead_gen', target: 100, unit: 'leads_per_month' }],
+    primaryChannels: ['linkedin'],
+    budget: {
+      currency: 'USD',
+      weeklyCap: 1000,
+      hardCap: 4000,
+      breakdown: { paidAds: 600, llmModelSpend: 200, rendering: 100, thirdPartyServices: 100 }
+    },
+    approvalPolicy: {
+      autoApproveReadinessThreshold: 0.8,
+      canaryInitialPct: 0.1,
+      canaryWatchWindowHours: 24,
+      manualApprovalForPaid: false,
+      legalManualApproval: false
+    },
+    riskProfile: 'medium',
+    connectors: [{ platform: 'linkedin', status: 'connected', lastConnectedAt: new Date().toISOString() }]
+  };
+
+  const mockResults = {
+    readinessScore: { mean: 0.9, confidence: { lower: 0.8, upper: 1, level: 0.95 } },
+    policyPassPct: { mean: 0.95 },
+    citationCoverage: { mean: 0.9 },
+    duplicationRisk: { mean: 0.1 },
+    costEstimate: { mean: 100 },
+    technicalReadiness: { mean: 0.85 },
+    convergenceMetrics: { converged: true, requiredIterations: 1, stabilityThreshold: 0.001 }
+  } as any;
+
+  beforeEach(() => {
+    jest.spyOn(MonteCarloEngine.prototype, 'runSimulation').mockResolvedValue(mockResults);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns 404 when workspace is missing', async () => {
+    (axios.get as jest.Mock).mockRejectedValue({ response: { status: 404 } });
+
+    const res = await request(app).post('/simulate').send({ workspaceId: 'missing', workflowJson: {} });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('WORKSPACE_NOT_FOUND');
+  });
+
+  it('returns simulation result when workspace exists', async () => {
+    (axios.get as jest.Mock).mockResolvedValue({ data: mockWorkspace });
+
+    const res = await request(app)
+      .post('/simulate')
+      .send({ workspaceId: 'ws-test', workflowJson: {}, iterations: 1, randomSeed: 42, timeoutSeconds: 10 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.readinessScore).toBe(mockResults.readinessScore.mean);
+  });
+});


### PR DESCRIPTION
## Summary
- fetch workspace context via axios instead of mock data
- handle missing or unreachable workspaces with explicit errors
- add simulator Jest config and tests stubbing external workspace lookup

## Testing
- `npm test` *(fails: mathjs quantile not a function, missing shared modules)*
- `npx jest test/server.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b972eeedd8832b8e91b6fd6cbff007
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Switches the simulator to fetch workspace context over HTTP from the SMM Architect service instead of mock data, with clear error handling for missing or unreachable workspaces. Adds targeted Jest tests and a local Jest config for the simulator service.

- **New Features**
  - Fetch workspace via axios from SMM Architect (configurable with SMM_ARCHITECT_URL, defaults to http://localhost:4000).
  - Structured errors: 404 returns WORKSPACE_NOT_FOUND; other service errors map to WORKSPACE_FETCH_FAILED; unreachable service returns 502.
  - Added simulator-specific Jest config and tests that mock axios for 404 and success paths.

- **Migration**
  - Set SMM_ARCHITECT_URL for simulator environments to point to the Architect service.
  - Ensure clients handle non-200 responses from /simulate, especially 404 WORKSPACE_NOT_FOUND.

<!-- End of auto-generated description by cubic. -->

