### PR TITLE
feat: add multi-provider KMS manager and audit integration

### DIFF
--- a/tests/integration/audit-service-kms.test.ts
+++ b/tests/integration/audit-service-kms.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from '@jest/globals';
+import { AuditService } from '../../services/smm-architect/src/services/audit-service';
+import { KMSManager } from '../../services/audit/src/kms/kms-manager';
+
+describe('AuditService KMS integration', () => {
+  it('signs and verifies audit bundles with local KMS', async () => {
+    const kmsManager = KMSManager.forTesting();
+    const keyId = await kmsManager.createKey('test-audit-key');
+
+    const auditService = new AuditService(kmsManager);
+    const original = (auditService as any).getWorkspaceContract.bind(auditService);
+    (auditService as any).getWorkspaceContract = async (workspaceId: string) => {
+      const contract = await original(workspaceId);
+      contract.kmsKeyRef = keyId;
+      return contract;
+    };
+
+    const bundle = await auditService.getAuditBundle('ws-1');
+    expect(bundle.signature).toBeDefined();
+
+    const valid = await auditService.verifyBundleSignature(
+      bundle.bundleId,
+      bundle.signature.signature,
+      bundle
+    );
+    expect(valid).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- extend KMS manager to support AWS, GCP, Vault via dynamic adapters
- wire AuditService with configurable KMSManager
- add integration test ensuring bundles sign and verify against local KMS

## Testing
- `node node_modules/jest/bin/jest.js tests/integration/audit-service-kms.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b972fad054832b80f8547b1c153fca