### PR TITLE
chore: expand production scans

### DIFF
--- a/tools/scripts/production-readiness-check.sh
+++ b/tools/scripts/production-readiness-check.sh
@@ -129,7 +129,7 @@ check_security() {
     log_info "=== Running Security Checks ==="
     
     # Check for sensitive data in code
-    run_check "No hardcoded secrets in code" "! grep -r -E '(password|secret|key).*=.*[\"'\"'][^\"'\"']{8,}' '$PROJECT_ROOT/src' '$PROJECT_ROOT/services' 2>/dev/null || true"
+    run_check "No hardcoded secrets in code" "! grep -r -E '(password|secret|key).*=.*[\"'\"'][^\"'\"']{8,}' '$PROJECT_ROOT/apps' '$PROJECT_ROOT/packages' '$PROJECT_ROOT/services' 2>/dev/null || true"
     
     # Check RBAC configurations
     run_check "RBAC configurations exist" "find '$PROJECT_ROOT' -name '*.yaml' -exec grep -l 'rbac.authorization.k8s.io' {} \\; | wc -l | grep -v '^0$' >/dev/null"
@@ -158,7 +158,7 @@ check_code_quality() {
     run_check "Unit tests pass" "cd '$PROJECT_ROOT' && npm test >/dev/null 2>&1" false
     
     # Check for TODO/FIXME comments
-    run_check "No critical TODOs in production code" "! grep -r -E '(TODO|FIXME|HACK).*CRITICAL' '$PROJECT_ROOT/src' '$PROJECT_ROOT/services' 2>/dev/null || true"
+    run_check "No critical TODOs in production code" "! grep -r -E '(TODO|FIXME|HACK).*CRITICAL' '$PROJECT_ROOT/apps' '$PROJECT_ROOT/packages' '$PROJECT_ROOT/services' 2>/dev/null || true"
 }
 
 # Validate database migrations and schema


### PR DESCRIPTION
### **User description**
## Summary
- ensure secret scan checks apps, packages, and services
- ensure TODO scan covers apps, packages, and services

## Testing
- `npm test` *(fails: command (/workspace/smm-architect/services/smm-architect) /root/.nvm/versions/node/v20.19.4/bin/pnpm run build exited (1))*
- `npm run lint` *(fails: command (/workspace/smm-architect/services/publisher) /root/.nvm/versions/node/v20.19.4/bin/pnpm run lint exited (1))*

------
https://chatgpt.com/codex/tasks/task_e_68b9db87563c832b9342bd9de9879f6d


___

### **PR Type**
Other


___

### **Description**
- Update directory references in production readiness checks

- Expand security scans to include `apps` and `packages`

- Expand TODO scans to cover all project directories


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Security Scan"] --> B["apps/"]
  A --> C["packages/"]
  A --> D["services/"]
  E["TODO Scan"] --> B
  E --> C
  E --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>production-readiness-check.sh</strong><dd><code>Expand scan coverage to include apps and packages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tools/scripts/production-readiness-check.sh

<ul><li>Updated hardcoded secrets check to scan <code>apps</code>, <code>packages</code>, and <code>services</code> <br>directories<br> <li> Updated critical TODO check to scan <code>apps</code>, <code>packages</code>, and <code>services</code> <br>directories</ul>


</details>


  </td>
  <td><a href="https://github.com/eipp/smm-architect/pull/34/files#diff-6a1cc7d0bb2b08b287a00e0d68b4a8bd5247dc79d2d248667a62f5a08a42a6cb">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

