### PR TITLE
feat: archive TTL workspaces to S3

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1057,6 +1057,9 @@ importers:
 
   services/smm-architect:
     dependencies:
+      '@aws-sdk/client-s3':
+        specifier: ^3.445.0
+        version: 3.876.0
       '@google-cloud/kms':
         specifier: ^4.0.0
         version: 4.5.0
@@ -1100,6 +1103,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^6.0.0
         version: 6.21.0(eslint@8.57.1)(typescript@5.9.2)
+      aws-sdk-client-mock:
+        specifier: ^4.1.0
+        version: 4.1.0
       eslint:
         specifier: ^8.50.0
         version: 8.57.1
@@ -9947,6 +9953,29 @@ packages:
       '@sinonjs/commons': 3.0.1
     dev: true
 
+  /@sinonjs/fake-timers@11.2.2:
+    resolution: {integrity: sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==}
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+    dev: true
+
+  /@sinonjs/fake-timers@13.0.5:
+    resolution: {integrity: sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==}
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+    dev: true
+
+  /@sinonjs/samsam@8.0.3:
+    resolution: {integrity: sha512-hw6HbX+GyVZzmaYNh82Ecj1vdGZrqVIn/keDTg63IgAwiQPO+xCz99uG6Woqgb4tM0mUiFENKZ4cqd7IX94AXQ==}
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+      type-detect: 4.1.0
+    dev: true
+
+  /@sinonjs/text-encoding@0.7.3:
+    resolution: {integrity: sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==}
+    dev: true
+
   /@smithy/abort-controller@4.0.5:
     resolution: {integrity: sha512-jcrqdTQurIrBbUm4W2YdLVMQDoL0sA9DTxYd2s+R/y+2U9NLOP7Xf/YqfSg1FZhlZIYEnvk2mwbyvIfdLEPo8g==}
     engines: {node: '>=18.0.0'}
@@ -12057,6 +12086,16 @@ packages:
     resolution: {integrity: sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==}
     dev: false
 
+  /@types/sinon@17.0.4:
+    resolution: {integrity: sha512-RHnIrhfPO3+tJT0s7cFaXGZvsL4bbR3/k7z3P312qMS4JaS2Tk+KiwiLx1S0rQ56ERj00u1/BtdyVd0FY+Pdew==}
+    dependencies:
+      '@types/sinonjs__fake-timers': 8.1.5
+    dev: true
+
+  /@types/sinonjs__fake-timers@8.1.5:
+    resolution: {integrity: sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==}
+    dev: true
+
   /@types/stack-utils@2.0.3:
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
     dev: true
@@ -13349,6 +13388,14 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       possible-typed-array-names: 1.1.0
+
+  /aws-sdk-client-mock@4.1.0:
+    resolution: {integrity: sha512-h/tOYTkXEsAcV3//6C1/7U4ifSpKyJvb6auveAepqqNJl6TdZaPFEtKjBQNf8UxQdDP850knB2i/whq4zlsxJw==}
+    dependencies:
+      '@types/sinon': 17.0.4
+      sinon: 18.0.1
+      tslib: 2.8.1
+    dev: true
 
   /aws-sdk@2.1692.0:
     resolution: {integrity: sha512-x511uiJ/57FIsbgUe5csJ13k3uzu25uWQE+XqfBis/sB0SFoiElJWXRkgEAUh0U6n40eT3ay5Ue4oPkRMu1LYw==}
@@ -15319,6 +15366,11 @@ packages:
   /diff@4.0.2:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
     engines: {node: '>=0.3.1'}
+
+  /diff@5.2.0:
+    resolution: {integrity: sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==}
+    engines: {node: '>=0.3.1'}
+    dev: true
 
   /diffie-hellman@5.0.3:
     resolution: {integrity: sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==}
@@ -19237,6 +19289,10 @@ packages:
     resolution: {integrity: sha512-S59eriX5u3/QhMNq3v/gm8Kd0w8OS6Tz2FS1NG4blv+z0MuQcBRJyFWjdovM0Rad4/P4aUPFtnkNjMjyMlMSYA==}
     dev: false
 
+  /just-extend@6.2.0:
+    resolution: {integrity: sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==}
+    dev: true
+
   /jwa@1.4.2:
     resolution: {integrity: sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==}
     dependencies:
@@ -20241,6 +20297,16 @@ packages:
       - '@babel/core'
       - babel-plugin-macros
 
+  /nise@6.1.1:
+    resolution: {integrity: sha512-aMSAzLVY7LyeM60gvBS423nBmIPP+Wy7St7hsb+8/fc1HmeoHJfLO8CKse4u3BtOZvQLJghYPI2i/1WZrEj5/g==}
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+      '@sinonjs/fake-timers': 13.0.5
+      '@sinonjs/text-encoding': 0.7.3
+      just-extend: 6.2.0
+      path-to-regexp: 8.2.0
+    dev: true
+
   /no-case@3.0.4:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
     dependencies:
@@ -21027,7 +21093,6 @@ packages:
   /path-to-regexp@8.2.0:
     resolution: {integrity: sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==}
     engines: {node: '>=16'}
-    dev: false
 
   /path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -22957,6 +23022,17 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       semver: 7.7.2
+    dev: true
+
+  /sinon@18.0.1:
+    resolution: {integrity: sha512-a2N2TDY1uGviajJ6r4D1CyRAkzE9NNVlYOV1wX5xQDuAk0ONgzgRl0EjCQuRCPxOwp13ghsMwt9Gdldujs39qw==}
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+      '@sinonjs/fake-timers': 11.2.2
+      '@sinonjs/samsam': 8.0.3
+      diff: 5.2.0
+      nise: 6.1.1
+      supports-color: 7.2.0
     dev: true
 
   /sirv@2.0.4:

--- a/services/smm-architect/package.json
+++ b/services/smm-architect/package.json
@@ -10,40 +10,40 @@
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "test:performance": "jest --testPathPattern=performance --runInBand --detectOpenHandles",
-    "test:schema": "jest --testPathPattern=schema",
+    "test:schema": "jest --testNamePattern='schema' --timeout=60000",
     "benchmark": "npm run test:performance -- --verbose --outputFile=jest-performance-results.json",
     "test:contract": "jest --testNamePattern='pact' --runInBand",
     "test:model-evaluation": "jest --testNamePattern='model-evaluation' --timeout=300000",
     "test:drift-detection": "jest --testNamePattern='drift-detection' --timeout=120000",
     "test:security": "jest --testNamePattern='security' --timeout=180000",
-    "test:schema": "jest --testNamePattern='schema' --timeout=60000",
     "lint": "eslint src/**/*.ts",
     "lint:fix": "eslint src/**/*.ts --fix",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "encore.dev": "^1.0.0",
+    "@aws-sdk/client-s3": "^3.445.0",
     "@google-cloud/kms": "^4.0.0",
-    "node-vault": "^0.10.0",
-    "ajv": "^8.12.0",
-    "winston": "^3.11.0",
-    "uuid": "^9.0.0",
-    "date-fns": "^2.30.0",
     "@sentry/node": "^7.99.0",
-    "@sentry/profiling-node": "^7.99.0"
+    "@sentry/profiling-node": "^7.99.0",
+    "ajv": "^8.12.0",
+    "date-fns": "^2.30.0",
+    "encore.dev": "^1.0.0",
+    "node-vault": "^0.10.0",
+    "uuid": "^9.0.0",
+    "winston": "^3.11.0"
   },
   "devDependencies": {
+    "@types/jest": "^29.5.0",
     "@types/node": "^20.0.0",
     "@types/uuid": "^9.0.0",
-    "@types/jest": "^29.5.0",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
+    "aws-sdk-client-mock": "^4.1.0",
     "eslint": "^8.50.0",
     "jest": "^29.7.0",
+    "nock": "^13.3.3",
     "ts-jest": "^29.1.0",
-    "typescript": "^5.2.0",
-
-    "nock": "^13.3.3"
+    "typescript": "^5.2.0"
   },
   "keywords": [
     "smm",

--- a/services/smm-architect/src/utils/logger.ts
+++ b/services/smm-architect/src/utils/logger.ts
@@ -1,0 +1,7 @@
+import winston from 'winston';
+
+export const logger = winston.createLogger({
+  level: process.env.NODE_ENV === 'production' ? 'info' : 'debug',
+  transports: [new winston.transports.Console()],
+});
+

--- a/services/smm-architect/tests/ttl-archival-job.test.ts
+++ b/services/smm-architect/tests/ttl-archival-job.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { mockClient } from 'aws-sdk-client-mock';
+import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { gunzipSync } from 'zlib';
+
+import { TTLArchivalJob, TTLArchivalConfig } from '../src/jobs/ttl-archival-job';
+
+jest.mock('@smm-architect/shared/database/client', () => ({
+  DatabaseClient: class {}
+}));
+
+describe('TTLArchivalJob S3 archival', () => {
+  const s3Mock = mockClient(S3Client);
+
+  beforeEach(() => {
+    s3Mock.reset();
+    s3Mock.on(PutObjectCommand).resolves({});
+  });
+
+  it('uploads compressed data and returns the S3 URI', async () => {
+    const config: TTLArchivalConfig = {
+      dryRun: true,
+      batchSize: 1,
+      maxConcurrency: 1,
+      archiveToS3: true,
+      s3Bucket: 'test-bucket',
+      retentionDays: 30,
+    };
+
+    const job = new TTLArchivalJob({} as any, config);
+    const dateSpy = jest.spyOn(Date, 'now').mockReturnValue(1700000000000);
+
+    const uri = await (job as any).archiveToS3('ws-123', { hello: 'world' });
+
+    expect(uri).toBe('s3://test-bucket/archived-workspaces/ws-123/1700000000000.json.gz');
+
+    const calls = s3Mock.commandCalls(PutObjectCommand);
+    expect(calls.length).toBe(1);
+    const input = calls[0].args[0].input as any;
+    expect(input.Bucket).toBe('test-bucket');
+    expect(input.Key).toBe('archived-workspaces/ws-123/1700000000000.json.gz');
+
+    const uploaded = gunzipSync(input.Body as Buffer).toString();
+    expect(uploaded).toBe(JSON.stringify({ hello: 'world' }));
+
+    dateSpy.mockRestore();
+  });
+});
+


### PR DESCRIPTION
## Summary
- compress and upload expired workspace data to S3 using AWS SDK
- add winston logger and unit test for S3 archival

## Testing
- `pnpm -F smm-architect-service test`
- `pnpm -F smm-architect-service run test:security`
- `pnpm -F smm-architect-service lint` *(fails: ESLint couldn't find config "@typescript-eslint/recommended")*

------
https://chatgpt.com/codex/tasks/task_e_68b9db863b98832ba4ab0fea3a39f3bb