### PR TITLE
docs: clarify Prisma runtime comments

### DIFF
--- a/packages/shared/src/generated/client/runtime/library.d.ts
+++ b/packages/shared/src/generated/client/runtime/library.d.ts
@@ -863,7 +863,7 @@ export declare namespace DMMF {
         delete = "delete",
         deleteMany = "deleteMany",
         groupBy = "groupBy",
-        count = "count",// TODO: count does not actually exist, why?
+        count = "count",
         aggregate = "aggregate",
         findRaw = "findRaw",
         aggregateRaw = "aggregateRaw"
@@ -2593,9 +2593,13 @@ declare type QueryMiddlewareParams = {
     model?: string;
     /** The action that is being handled */
     action: Action;
-    /** TODO what is this */
+    /**
+     * Path to the property being operated on, used for nested writes.
+     */
     dataPath: string[];
-    /** TODO what is this */
+    /**
+     * Whether the query is executed inside an active transaction.
+     */
     runInTransaction: boolean;
     args?: UserArgs_2;
 };


### PR DESCRIPTION
## Summary
- remove outdated TODOs in generated Prisma client enums
- document middleware parameters for data path and transactions

## Testing
- `npm test` *(fails: turbo: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9db84a054832ba25dd980378ae51e
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Cleaned up Prisma client runtime typings and comments. Removed outdated TODOs in the Action enum and documented QueryMiddlewareParams dataPath and runInTransaction to make middleware usage clearer.

<!-- End of auto-generated description by cubic. -->

