### PR TITLE
chore: declare proprietary license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+SMM Architect Proprietary License
+
+Copyright (c) 2024 SMM Architect Team. All rights reserved.
+
+This software and associated documentation files (the "Software") are proprietary and confidential.
+Unauthorized copying, modification, distribution, or use of the Software, in whole or in part,
+without the express written permission of the SMM Architect Team is strictly prohibited.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -453,7 +453,7 @@ See `examples/workspace-contract.icblabs.json` for a complete example workspace 
 
 ## 📄 License
 
-This project is proprietary software. See [LICENSE](LICENSE) for details.
+This project is proprietary software released under the SMM Architect Proprietary License. See [LICENSE](LICENSE) for details.
 
 ## 🙋‍♀️ Support
 

--- a/package.json
+++ b/package.json
@@ -131,5 +131,5 @@
     "validation"
   ],
   "author": "SMM Architect Team",
-  "license": "MIT"
+  "license": "Proprietary"
 }


### PR DESCRIPTION
## Summary
- add proprietary license file
- mark package and docs as Proprietary

## Testing
- `make test` *(fails: `encore: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68b9db8143cc832b8cf4e983795d42b1