### PR TITLE
Add proprietary license and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [1.0.0] - 2024-08-26
+### Added
+- Initial production release.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,12 @@
+Copyright (c) 2024 SMM Architect Team
+
+All rights reserved.
+
+This software and associated documentation files (the "Software") are proprietary to the SMM Architect Team.
+Unauthorized copying, modification, distribution, or use of the Software, in whole or in part, is strictly prohibited without
+prior written permission from the copyright holders.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT, OR OTHERWISE, ARISING FROM, OUT OF, OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
## Summary
- add proprietary LICENSE file
- document initial 1.0.0 release in CHANGELOG

## Testing
- `npm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9db80bfac832bbaeeb9bd03e007d6
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add a proprietary LICENSE and a CHANGELOG documenting the 1.0.0 initial production release. This formalizes licensing and version history.

<!-- End of auto-generated description by cubic. -->

