### PR TITLE
chore: update pulumi paths in verification script

### DIFF
--- a/tools/scripts/verify-production-ready.sh
+++ b/tools/scripts/verify-production-ready.sh
@@ -90,8 +90,8 @@ echo ""
 print_header "TASK 2: WORKSPACE PROVISIONING DEPENDENCIES"
 echo "==========================================="
 
-verify_file_exists "Pulumi Infrastructure Code" "infra/pulumi/workspace-provisioning.ts" "false"
-verify_file_exists "Infrastructure Configuration" "infra/pulumi/Pulumi.yaml" "false"
+verify_file_exists "Pulumi Infrastructure Code" "infrastructure/pulumi/main.ts" "false"
+verify_file_exists "Infrastructure Configuration" "infrastructure/pulumi/Pulumi.yaml" "false"
 verify_content_exists "Package Dependencies Fixed" "package.json" '"overrides"' "true"
 
 print_success "✅ TASK 2: Workspace Provisioning Dependencies - VERIFIED"


### PR DESCRIPTION
## Summary
- point production verification script to new pulumi main.ts and Pulumi.yaml locations

## Testing
- `tools/scripts/verify-production-ready.sh` *(failed: missing KMS components)*
- `make test` *(failed: turbo not found)*
- `make test-security` *(failed: missing RLS policies)*

------
https://chatgpt.com/codex/tasks/task_e_68b9db7e2bd8832b990327cdf270e0a7
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Update verify-production-ready.sh to use the new Pulumi paths so the checks run against current infrastructure code. Replaces infra/pulumi references with infrastructure/pulumi/main.ts and infrastructure/pulumi/Pulumi.yaml.

<!-- End of auto-generated description by cubic. -->

