### PR TITLE
fix: update pulumi paths in production verification script

### DIFF
--- a/tools/scripts/verify-production-ready.sh
+++ b/tools/scripts/verify-production-ready.sh
@@ -3,6 +3,7 @@
 # SMM Architect - FINAL PRODUCTION VERIFICATION
 # Comprehensive validation of all 10 production-ready tasks
 
+# Exit immediately on unhandled errors in verification logic
 set -e
 
 echo "🏁 SMM ARCHITECT - FINAL PRODUCTION VERIFICATION"
@@ -35,12 +36,12 @@ verify_item() {
     local check_command="$2"
     local is_critical="${3:-false}"
     
-    ((TOTAL_VERIFICATIONS++))
+    ((TOTAL_VERIFICATIONS+=1))
     print_status "Verifying: $name"
     
     if eval "$check_command" >/dev/null 2>&1; then
         print_success "✅ $name"
-        ((PASSED_VERIFICATIONS++))
+        ((PASSED_VERIFICATIONS+=1))
         return 0
     else
         if [ "$is_critical" = "true" ]; then
@@ -48,7 +49,7 @@ verify_item() {
         else
             print_warning "⚠️ $name"
         fi
-        ((FAILED_VERIFICATIONS++))
+        ((FAILED_VERIFICATIONS+=1))
         return 1
     fi
 }
@@ -90,8 +91,8 @@ echo ""
 print_header "TASK 2: WORKSPACE PROVISIONING DEPENDENCIES"
 echo "==========================================="
 
-verify_file_exists "Pulumi Infrastructure Code" "infra/pulumi/workspace-provisioning.ts" "false"
-verify_file_exists "Infrastructure Configuration" "infra/pulumi/Pulumi.yaml" "false"
+verify_file_exists "Pulumi Infrastructure Code" "infrastructure/pulumi/main.ts" "false"
+verify_file_exists "Infrastructure Configuration" "infrastructure/pulumi/Pulumi.yaml" "false"
 verify_content_exists "Package Dependencies Fixed" "package.json" '"overrides"' "true"
 
 print_success "✅ TASK 2: Workspace Provisioning Dependencies - VERIFIED"


### PR DESCRIPTION
## Summary
- correct Pulumi code/config paths in verify-production-ready script
- ensure verification counters increment without exiting under `set -e`

## Testing
- `tools/scripts/verify-production-ready.sh` *(fails: ❌ CRITICAL: Production KMS Adapter)*
- `npm test` *(fails: turbo: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9da03fe70832b83f454e721da3431