### PR TITLE
Implement S3 archival to S3 with verification

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1057,6 +1057,9 @@ importers:
 
   services/smm-architect:
     dependencies:
+      '@aws-sdk/client-s3':
+        specifier: ^3.876.0
+        version: 3.876.0
       '@google-cloud/kms':
         specifier: ^4.0.0
         version: 4.5.0

--- a/services/smm-architect/package.json
+++ b/services/smm-architect/package.json
@@ -30,7 +30,8 @@
     "uuid": "^9.0.0",
     "date-fns": "^2.30.0",
     "@sentry/node": "^7.99.0",
-    "@sentry/profiling-node": "^7.99.0"
+    "@sentry/profiling-node": "^7.99.0",
+    "@aws-sdk/client-s3": "^3.876.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",


### PR DESCRIPTION
## Summary
- implement gzip compression and AWS S3 upload with ETag verification in TTL archival job
- add `@aws-sdk/client-s3` dependency for archival support

## Testing
- `make test` *(fails: encore CLI not found)*
- `make test-security` *(fails: 54 RLS policy violations)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d6e1f720832baaf0ed4c6c5da314
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds gzip-compressed archival of workspace data to S3 in the TTL archival job, with MD5/ETag verification for data integrity. Returns the S3 URI on success.

- **New Features**
  - Gzip JSON and upload via S3 PutObject.
  - Verify upload by matching MD5 to S3 ETag (via HeadObject).
  - Store at s3://{bucket}/archived-workspaces/{workspace_id}/{timestamp}.json.gz.
  - Requires s3Bucket in config; uses AWS_REGION (defaults to us-east-1).

- **Dependencies**
  - Added @aws-sdk/client-s3 (^3.876.0).
  - Ensure IAM allows s3:PutObject and s3:HeadObject on the target bucket.

<!-- End of auto-generated description by cubic. -->

