### PR TITLE
chore: add license compliance checks to sbom

### DIFF
--- a/.github/workflows/sbom-monitoring.yml
+++ b/.github/workflows/sbom-monitoring.yml
@@ -89,10 +89,13 @@ jobs:
 
     - name: Run comprehensive SBOM generation
       run: |
-        chmod +x scripts/generate-sbom.sh
-        ./scripts/generate-sbom.sh
+        chmod +x tools/scripts/generate-sbom.sh
+        tools/scripts/generate-sbom.sh
       env:
         SBOM_STORAGE_BUCKET: ${{ secrets.SBOM_STORAGE_BUCKET }}
+
+    - name: Verify license compliance
+      run: tools/scripts/verify-license-compliance.sh
 
     - name: Vulnerability scanning with Grype
       run: |

--- a/.github/workflows/security-gates.yml
+++ b/.github/workflows/security-gates.yml
@@ -105,7 +105,7 @@ jobs:
           npm audit --audit-level=high
           
           # Generate SBOM and vulnerability report
-          ./scripts/generate-sbom.sh
+          tools/scripts/generate-sbom.sh
           
           # Check for critical vulnerabilities in SBOM reports
           if find sbom/vulnerabilities/ -name "*.json" -exec jq -e '.matches[] | select(.vulnerability.severity == "Critical" or .vulnerability.severity == "High")' {} \; 2>/dev/null; then
@@ -292,29 +292,12 @@ jobs:
       - name: Generate and verify SBOM
         run: |
           echo "🔍 Generating comprehensive SBOM..."
-          ./scripts/generate-sbom.sh
-          
+          tools/scripts/generate-sbom.sh
+
           echo "✅ SBOM generation completed"
 
       - name: License compliance check
-        run: |
-          echo "📜 Checking license compliance..."
-          
-          # Extract licenses from SBOM
-          find sbom/services/ -name "*.json" -exec jq -r '.components[]?.licenses[]?.license.name // empty' {} \; | sort -u > detected-licenses.txt
-          
-          # Check for problematic licenses
-          PROBLEMATIC_LICENSES=("GPL-3.0" "AGPL-3.0" "SSPL-1.0" "BUSL-1.1")
-          
-          for license in "${PROBLEMATIC_LICENSES[@]}"; do
-            if grep -q "$license" detected-licenses.txt; then
-              echo "❌ Problematic license detected: $license"
-              echo "Review license compatibility before production deployment"
-              exit 1
-            fi
-          done
-          
-          echo "✅ License compliance check passed"
+        run: tools/scripts/verify-license-compliance.sh
 
       - name: Upload SBOM artifacts
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -401,6 +401,11 @@ cd services/toolhub && pnpm test:benchmark
 - Data retention policies
 - Right to deletion support
 
+### License Compliance
+- SBOM generation includes license metadata for every dependency
+- CI workflows verify that all licenses are declared and acceptable
+- See [docs/licensing-compliance.md](docs/licensing-compliance.md) for details
+
 ## 🔧 Configuration
 
 ### Environment Variables

--- a/docs/licensing-compliance.md
+++ b/docs/licensing-compliance.md
@@ -1,0 +1,48 @@
+# Licensing Compliance Guide
+
+## Overview
+
+SMM Architect requires every dependency to declare a valid software license.
+This guide explains how license information is collected, verified, and
+automatically enforced in continuous integration.
+
+## Generating SBOMs with License Data
+
+Use the SBOM generation script to collect dependency information. The script
+retrieves missing license metadata from the npm registry and embeds it into
+all SBOM files.
+
+```bash
+# Generate SBOMs for the entire platform
+tools/scripts/generate-sbom.sh
+```
+
+The script outputs a combined SBOM at
+`sbom/combined/smm-architect-complete-sbom.json` and a human readable
+inventory report under `sbom/reports/`.
+
+## Verifying License Compliance
+
+After SBOM generation, run the verification script to ensure every component
+has a license and no prohibited licenses are present.
+
+```bash
+# Verify that all dependencies have acceptable licenses
+tools/scripts/verify-license-compliance.sh
+```
+
+The script fails if any component is missing license information or if a
+component uses one of the disallowed licenses (`GPL-3.0`, `AGPL-3.0`,
+`SSPL-1.0`, or `BUSL-1.1`).
+
+## Continuous Integration
+
+The GitHub Actions workflows automatically run both scripts on each pull
+request. SBOM generation populates license fields and the verification step
+blocks the build when licensing requirements are not met.
+
+## Reporting Issues
+
+If the verification script fails, review the missing components and update the
+package metadata or replace the dependency with one that has a compatible
+license.

--- a/tools/scripts/verify-license-compliance.sh
+++ b/tools/scripts/verify-license-compliance.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -euo pipefail
+
+# License compliance verification script
+# Ensures SBOM contains license information for all components
+# and checks for disallowed licenses.
+
+SBOM_FILE="${1:-sbom/combined/smm-architect-complete-sbom.json}"
+
+if [[ ! -f "$SBOM_FILE" ]]; then
+  echo "SBOM file not found: $SBOM_FILE" >&2
+  exit 1
+fi
+
+# Check for missing license information
+missing=$(jq -r '.components[] | select(.licenses == null or (.licenses | length == 0) or ([.licenses[].license.name] | any(. == "" or . == "Unknown"))) | "\(.name)@\(.version)"' "$SBOM_FILE")
+
+if [[ -n "$missing" ]]; then
+  echo "❌ Missing license information for:" >&2
+  echo "$missing" >&2
+  exit 1
+fi
+
+# Check for problematic licenses
+PROBLEMATIC_LICENSES=("GPL-3.0" "AGPL-3.0" "SSPL-1.0" "BUSL-1.1")
+
+detected=$(jq -r '.components[]?.licenses[]?.license.name // empty' "$SBOM_FILE" | sort -u)
+
+for bad in "${PROBLEMATIC_LICENSES[@]}"; do
+  if echo "$detected" | grep -q "$bad"; then
+    echo "❌ Problematic license detected: $bad" >&2
+    exit 1
+  fi
+done
+
+echo "✅ License compliance verified"


### PR DESCRIPTION
## Summary
- enrich SBOM generation to capture missing license metadata from npm
- add verify-license-compliance script and wire into CI workflows
- document license compliance process and link from README

## Testing
- `pre-commit run --files tools/scripts/generate-sbom.sh tools/scripts/verify-license-compliance.sh docs/licensing-compliance.md README.md .github/workflows/sbom-monitoring.yml .github/workflows/security-gates.yml` *(fails: Type tag 'typescript' is not recognized)*
- `make test` *(fails: @smm-architect/ui#build)*
- `make test-security` *(fails: RLS policy checks)*
- `tools/scripts/verify-license-compliance.sh sbom/combined/smm-architect-complete-sbom.json` *(fails: Missing license information for numerous packages)*

------
https://chatgpt.com/codex/tasks/task_e_68b99f664934832ba7d877b6246f5732
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Enforces license compliance in our SBOM pipeline. SBOMs now include license metadata from npm, and CI fails when licenses are missing or disallowed.

- New Features
  - SBOM generation enriches missing license data via npm for services, infrastructure, and the combined SBOM.
  - Added tools/scripts/verify-license-compliance.sh to fail on missing licenses or prohibited ones (GPL-3.0, AGPL-3.0, SSPL-1.0, BUSL-1.1).
  - Updated CI workflows to use the new scripts and run license verification; added a licensing guide and linked it from the README.

- Migration
  - Use tools/scripts/generate-sbom.sh (path changed from scripts/).
  - Ensure npm is available in CI/local environments and run tools/scripts/verify-license-compliance.sh after SBOM generation.

<!-- End of auto-generated description by cubic. -->

