### PR TITLE
chore: remove placeholder comments from generated client

### DIFF
--- a/packages/shared/src/generated/client/runtime/library.d.ts
+++ b/packages/shared/src/generated/client/runtime/library.d.ts
@@ -863,7 +863,7 @@ export declare namespace DMMF {
         delete = "delete",
         deleteMany = "deleteMany",
         groupBy = "groupBy",
-        count = "count",// TODO: count does not actually exist, why?
+        count = "count",
         aggregate = "aggregate",
         findRaw = "findRaw",
         aggregateRaw = "aggregateRaw"
@@ -1023,9 +1023,6 @@ export declare type DynamicResultExtensionNeeds<TypeMap extends TypeMapDef, M ex
     [N in keyof TypeMap['model'][M]['payload']['scalars']]?: boolean;
 };
 
-/**
- * Placeholder value for "no text".
- */
 export declare const empty: Sql;
 
 export declare type EmptyToUnknown<T> = T;
@@ -2593,9 +2590,7 @@ declare type QueryMiddlewareParams = {
     model?: string;
     /** The action that is being handled */
     action: Action;
-    /** TODO what is this */
     dataPath: string[];
-    /** TODO what is this */
     runInTransaction: boolean;
     args?: UserArgs_2;
 };


### PR DESCRIPTION
## Summary
- remove TODO and placeholder comments from generated Prisma client typings

## Testing
- `make test` (fails: tsup not found in ui build)
- `make test-security` (fails: RLS policy requirements missing)


------
https://chatgpt.com/codex/tasks/task_e_68b99f647778832ba781932ddb376fe0
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed TODO and placeholder comments from the generated Prisma client typings to reduce noise and avoid misleading docs. No runtime or API changes; strictly comment cleanup in library.d.ts.

<!-- End of auto-generated description by cubic. -->

