### PR TITLE
feat: add runtime theming with dark mode

### DIFF
--- a/apps/frontend/README.md
+++ b/apps/frontend/README.md
@@ -34,3 +34,28 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Theming and Dark Mode
+
+This app includes a simple theme system powered by design tokens. Wrap your application in the `ThemeProvider` and use the `useTheme` hook to switch between light and dark modes at runtime:
+
+```tsx
+import { ThemeProvider, useTheme } from '@/contexts/theme-context'
+
+export const App = () => (
+  <ThemeProvider>
+    <Content />
+  </ThemeProvider>
+)
+
+const Content = () => {
+  const { theme, setTheme } = useTheme()
+  return (
+    <button onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}>
+      Toggle theme
+    </button>
+  )
+}
+```
+
+Design tokens are defined for both themes, and global styles automatically update when the theme changes.

--- a/apps/frontend/src/__tests__/theme.test.tsx
+++ b/apps/frontend/src/__tests__/theme.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ThemeProvider, useTheme } from '@/contexts/theme-context'
+
+const TestComponent = () => {
+  const { theme, setTheme } = useTheme()
+  return (
+    <button onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}>
+      toggle
+    </button>
+  )
+}
+
+describe('theme switching', () => {
+  it('toggles dark mode class on root', async () => {
+    const user = userEvent.setup()
+    render(
+      <ThemeProvider>
+        <TestComponent />
+      </ThemeProvider>
+    )
+    const button = screen.getByRole('button')
+    expect(document.documentElement.classList.contains('dark')).toBe(false)
+    await user.click(button)
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+  })
+})

--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -3,11 +3,11 @@
 @layer base {
   :root {
     /* Colors */
-    --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
-    --card: 0 0% 100%;
-    --card-foreground: 222.2 84% 4.9%;
-    --popover: 0 0% 100%;
+    --background: var(--color-canvas-background);
+    --foreground: var(--color-neutral-900);
+    --card: var(--color-workspace-background);
+    --card-foreground: var(--color-neutral-900);
+    --popover: var(--color-workspace-background);
     --popover-foreground: 222.2 84% 4.9%;
     --primary: 221.2 83.2% 53.3%;
     --primary-foreground: 210 40% 98%;
@@ -19,19 +19,19 @@
     --accent-foreground: 222.2 84% 4.9%;
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 210 40% 98%;
-    --border: 214.3 31.8% 91.4%;
-    --input: 214.3 31.8% 91.4%;
+    --border: var(--color-border-subtle);
+    --input: var(--color-border-subtle);
     --ring: 221.2 83.2% 53.3%;
     --radius: 0.5rem;
   }
 
   .dark {
-    --background: 222.2 84% 4.9%;
-    --foreground: 210 40% 98%;
-    --card: 222.2 84% 4.9%;
-    --card-foreground: 210 40% 98%;
-    --popover: 222.2 84% 4.9%;
-    --popover-foreground: 210 40% 98%;
+    --background: var(--color-canvas-background);
+    --foreground: var(--color-neutral-50);
+    --card: var(--color-workspace-background);
+    --card-foreground: var(--color-neutral-50);
+    --popover: var(--color-workspace-background);
+    --popover-foreground: var(--color-neutral-50);
     --primary: 217.2 91.2% 59.8%;
     --primary-foreground: 222.2 84% 4.9%;
     --secondary: 217.2 32.6% 17.5%;
@@ -42,8 +42,8 @@
     --accent-foreground: 210 40% 98%;
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 210 40% 98%;
-    --border: 217.2 32.6% 17.5%;
-    --input: 217.2 32.6% 17.5%;
+    --border: var(--color-border-strong);
+    --input: var(--color-border-strong);
     --ring: 224.3 76.3% 94.1%;
   }
 }

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -7,6 +7,7 @@ import { Toaster } from "@/components/ui/toaster"
 import { ErrorBoundary } from "@/components/error-boundary"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { I18nProvider } from "@/lib/i18n"
+import { ThemeProvider } from "@/contexts/theme-context"
 import PerformanceMonitoring from "@/components/core-web-vitals"
 
 // Inter Variable font with optimized loading strategy
@@ -118,18 +119,20 @@ export default function RootLayout({
         className={`${inter.variable} ${jetbrainsMono.variable} font-sans antialiased bg-background text-foreground`}
       >
         <ErrorBoundary>
-          <I18nProvider>
-            <TooltipProvider>
-              <div className="relative min-h-screen flex flex-col">
-                <Navigation />
-                <main className="flex-1">
-                  {children}
-                </main>
-              </div>
-              <Toaster />
-              <PerformanceMonitoring />
-            </TooltipProvider>
-          </I18nProvider>
+          <ThemeProvider>
+            <I18nProvider>
+              <TooltipProvider>
+                <div className="relative min-h-screen flex flex-col">
+                  <Navigation />
+                  <main className="flex-1">
+                    {children}
+                  </main>
+                </div>
+                <Toaster />
+                <PerformanceMonitoring />
+              </TooltipProvider>
+            </I18nProvider>
+          </ThemeProvider>
         </ErrorBoundary>
       </body>
     </html>

--- a/apps/frontend/src/contexts/theme-context.tsx
+++ b/apps/frontend/src/contexts/theme-context.tsx
@@ -1,0 +1,30 @@
+import React, { createContext, useContext, useEffect, useState } from 'react'
+import { setTheme, ThemeName, prefersDarkMode } from '@/design-system'
+
+interface ThemeContextValue {
+  theme: ThemeName
+  setTheme: (theme: ThemeName) => void
+}
+
+const ThemeContext = createContext<ThemeContextValue>({
+  theme: 'light',
+  setTheme: () => {},
+})
+
+export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
+  const [theme, setThemeState] = useState<ThemeName>(() =>
+    prefersDarkMode() ? 'dark' : 'light'
+  )
+
+  useEffect(() => {
+    setTheme(theme)
+  }, [theme])
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme: setThemeState }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}
+
+export const useTheme = () => useContext(ThemeContext)

--- a/apps/frontend/src/design-system/index.ts
+++ b/apps/frontend/src/design-system/index.ts
@@ -1,6 +1,7 @@
+import type { ThemeName } from './tokens';
 // Design System Exports
-export { default as tokens, motionConfig } from './tokens';
-export type { DesignTokens, MotionConfig } from './tokens';
+export { default as tokens, motionConfig, themes, getThemeTokens } from './tokens';
+export type { DesignTokens, MotionConfig, ThemeName } from './tokens';
 
 export { 
   getMotionConfig, 
@@ -103,6 +104,12 @@ export const prefersDarkMode = () => {
   return window.matchMedia('(prefers-color-scheme: dark)').matches;
 };
 
+export const setTheme = (theme: ThemeName) => {
+  if (typeof document === 'undefined') return;
+  document.documentElement.setAttribute('data-theme', theme);
+  document.documentElement.classList.toggle('dark', theme === 'dark');
+};
+
 // Export everything as default for convenience
 export default {
   tokens,
@@ -124,5 +131,8 @@ export default {
   createAnimation,
   createLayout,
   isLightMode,
-  prefersDarkMode
+  prefersDarkMode,
+  setTheme,
+  themes,
+  getThemeTokens
 };

--- a/apps/frontend/src/design-system/tokens.css
+++ b/apps/frontend/src/design-system/tokens.css
@@ -181,3 +181,23 @@
   --modal-max-width: 640px;
   --modal-padding: 24px;
 }
+
+.dark {
+  --color-neutral-50: hsl(210 15% 8%);
+  --color-neutral-100: hsl(210 15% 12%);
+  --color-neutral-200: hsl(210 15% 22%);
+  --color-neutral-300: hsl(210 15% 32%);
+  --color-neutral-400: hsl(210 15% 42%);
+  --color-neutral-500: hsl(210 15% 55%);
+  --color-neutral-600: hsl(210 20% 70%);
+  --color-neutral-700: hsl(210 25% 85%);
+  --color-neutral-800: hsl(210 30% 92%);
+  --color-neutral-900: hsl(210 40% 96%);
+  --color-neutral-950: hsl(210 40% 98%);
+
+  --color-canvas-background: hsl(210 30% 8%);
+  --color-workspace-background: hsl(0 0% 10%);
+  --color-surface-elevated: hsl(210 15% 20%);
+  --color-border-subtle: hsl(210 15% 30%);
+  --color-border-strong: hsl(210 20% 40%);
+}

--- a/apps/frontend/src/design-system/tokens.ts
+++ b/apps/frontend/src/design-system/tokens.ts
@@ -5,7 +5,8 @@ export const motionConfig = {
   fade: { duration: 0.2, ease: [0.2, 0.9, 0.2, 1] as [number, number, number, number] }
 };
 
-export const tokens = {
+// Base design tokens for the light theme
+const lightTokens = {
   color: {
     primary: {
       50: 'hsl(215 100% 97%)',
@@ -210,7 +211,48 @@ export const tokens = {
   }
 } as const;
 
-export type DesignTokens = typeof tokens;
+// Dark theme tokens extend the light theme with inverted neutral and semantic colors
+const darkTokens: typeof lightTokens = {
+  ...lightTokens,
+  color: {
+    ...lightTokens.color,
+    neutral: {
+      50: 'hsl(210 15% 8%)',
+      100: 'hsl(210 15% 12%)',
+      200: 'hsl(210 15% 22%)',
+      300: 'hsl(210 15% 32%)',
+      400: 'hsl(210 15% 42%)',
+      500: 'hsl(210 15% 55%)',
+      600: 'hsl(210 20% 70%)',
+      700: 'hsl(210 25% 85%)',
+      800: 'hsl(210 30% 92%)',
+      900: 'hsl(210 40% 96%)',
+      950: 'hsl(210 40% 98%)'
+    },
+    semantic: {
+      ...lightTokens.color.semantic,
+      canvasBackground: 'hsl(210 30% 8%)',
+      workspaceBackground: 'hsl(0 0% 10%)',
+      surfaceElevated: 'hsl(210 15% 20%)',
+      borderSubtle: 'hsl(210 15% 30%)',
+      borderStrong: 'hsl(210 20% 40%)'
+    }
+  }
+} as const;
+
+export const themes = {
+  light: lightTokens,
+  dark: darkTokens
+} as const;
+
+export type ThemeName = keyof typeof themes;
+
+// Default exported tokens are the light theme for backward compatibility
+export const tokens = themes.light;
+
+export const getThemeTokens = (theme: ThemeName) => themes[theme];
+
+export type DesignTokens = typeof lightTokens;
 export type MotionConfig = typeof motionConfig;
 
 export default tokens;


### PR DESCRIPTION
## Summary
- expand design tokens with light and dark themes and helpers
- wire ThemeProvider and global styles for runtime theme switching
- document and test theme usage

## Testing
- `npm test` *(fails: jest not found)*
- `make test` *(fails: turbo not found)*
- `make test-security` *(fails: dependency error)*

------
https://chatgpt.com/codex/tasks/task_e_68b99f60dc60832ba511acae517c0890