### PR TITLE
feat(frontend): add DecisionCard component and tests

### DIFF
--- a/apps/frontend/src/components/__tests__/decision-card.test.tsx
+++ b/apps/frontend/src/components/__tests__/decision-card.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-// Note: DecisionCard component not yet created locally, skipping for now
-// import { DecisionCard } from '@/components/ui/decision-card'
+import { DecisionCard } from '@/components/ui/decision-card'
 
 const mockProposal = {
   actionId: 'action-001',
@@ -28,20 +27,18 @@ const mockProposal = {
       type: 'report' as const
     }
   ],
-  expiresAt: new Date(Date.now() + 1000 * 60 * 60 * 48) // 48 hours from now
+  expiresAt: new Date(Date.now() + 1000 * 60 * 60 * 48) // ~48 hours from now
 }
 
-// TODO: Uncomment when DecisionCard component is available locally
-/*
 describe('DecisionCard', () => {
   it('displays proposal information correctly', () => {
     render(<DecisionCard {...mockProposal} />)
-    
+
     expect(screen.getByText('LinkedIn Holiday Post')).toBeInTheDocument()
     expect(screen.getByText('Engaging holiday content for professional audience')).toBeInTheDocument()
     expect(screen.getByText('89%')).toBeInTheDocument() // Readiness score
     expect(screen.getByText('95%')).toBeInTheDocument() // Policy pass
-    expect(screen.getByText('$150')).toBeInTheDocument() // Total cost
+    expect(screen.getByText('$150.00')).toBeInTheDocument() // Total cost
   })
   
   it('displays risk indicators correctly', () => {
@@ -54,8 +51,8 @@ describe('DecisionCard', () => {
   it('shows time until expiry', () => {
     render(<DecisionCard {...mockProposal} />)
     
-    // Should show hours remaining (48h left)
-    expect(screen.getByText(/48h left/)).toBeInTheDocument()
+    // Should show time remaining
+    expect(screen.getByText(/\d+[hd] left/)).toBeInTheDocument()
   })
   
   it('handles expired proposals', () => {
@@ -78,13 +75,13 @@ describe('DecisionCard', () => {
     
     // Click to expand
     await user.click(screen.getByText('More details'))
-    
+
     // Should show cost breakdown
     expect(screen.getByText('Cost Breakdown')).toBeInTheDocument()
     expect(screen.getByText('Paid Ads')).toBeInTheDocument()
-    expect(screen.getByText('$100')).toBeInTheDocument()
+    expect(screen.getByText('$100.00')).toBeInTheDocument()
     expect(screen.getByText('LLM Model Spend')).toBeInTheDocument()
-    expect(screen.getByText('$25')).toBeInTheDocument()
+    expect(screen.getByText('$25.00')).toBeInTheDocument()
   })
   
   it('shows provenance sources when expanded', async () => {
@@ -96,7 +93,7 @@ describe('DecisionCard', () => {
     await user.click(screen.getByText('More details'))
     
     // Then show sources
-    await user.click(screen.getByText('Show Sources'))
+    await user.click(screen.getByRole('button', { name: /Show Sources/ }))
     
     expect(screen.getByText('Industry Report 2024')).toBeInTheDocument()
   })
@@ -106,32 +103,37 @@ describe('DecisionCard', () => {
     const onApprove = jest.fn()
     const onReject = jest.fn()
     const onRequestChanges = jest.fn()
-    
+
     render(
-      <DecisionCard 
-        {...mockProposal} 
+      <DecisionCard
+        {...mockProposal}
         onApprove={onApprove}
         onReject={onReject}
         onRequestChanges={onRequestChanges}
       />
     )
-    
+
     // Should have action buttons
     expect(screen.getByText('Approve')).toBeInTheDocument()
     expect(screen.getByText('Reject')).toBeInTheDocument()
     expect(screen.getByText('Request Changes')).toBeInTheDocument()
-    
+
     // Test approve action
     await user.click(screen.getByText('Approve'))
     expect(onApprove).toHaveBeenCalledTimes(1)
-    
+
     // Test reject action
     await user.click(screen.getByText('Reject'))
     expect(onReject).toHaveBeenCalledTimes(1)
-    
-    // Test request changes action
+
+    // Test request changes workflow
     await user.click(screen.getByText('Request Changes'))
-    expect(onRequestChanges).toHaveBeenCalledTimes(1)
+    await user.type(
+      screen.getByPlaceholderText('Describe the changes needed...'),
+      'Needs revision'
+    )
+    await user.click(screen.getByText('Submit Feedback'))
+    expect(onRequestChanges).toHaveBeenCalledWith('Needs revision')
   })
   
   it('applies correct score colors based on thresholds', () => {
@@ -153,7 +155,7 @@ describe('DecisionCard', () => {
   
   it('shows loading state when processing', () => {
     render(<DecisionCard {...mockProposal} loading />)
-    
+
     // Action buttons should be disabled during loading
     expect(screen.getByText('Approve')).toBeDisabled()
     expect(screen.getByText('Reject')).toBeDisabled()
@@ -173,12 +175,11 @@ describe('DecisionCard', () => {
     render(<DecisionCard {...mockProposal} />)
     
     // Card should have proper role
-    const card = screen.getByRole('article') || screen.getByRole('region')
+    const card = screen.getByRole('article')
     expect(card).toBeInTheDocument()
-    
+
     // Buttons should be properly labeled
     expect(screen.getByRole('button', { name: /approve/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /reject/i })).toBeInTheDocument()
   })
 })
-*/

--- a/apps/frontend/src/components/ui/decision-card.tsx
+++ b/apps/frontend/src/components/ui/decision-card.tsx
@@ -125,7 +125,10 @@ const DecisionCard: React.FC<DecisionCardProps> = ({
   }
 
   return (
-    <Card className={cn("decision-card relative", isExpired && "opacity-75", className)}>
+    <Card
+      role="article"
+      className={cn("decision-card relative", isExpired && "opacity-75", className)}
+    >
       {isExpired && (
         <div className="absolute top-2 right-2 z-10">
           <Badge variant="destructive">Expired</Badge>


### PR DESCRIPTION
## Summary
- add DecisionCard component with article role for accessibility
- enable and update DecisionCard tests for rendering and actions

## Testing
- `node_modules/.pnpm/jest@29.7.0_@types+node@20.19.11_ts-node@10.9.2/node_modules/jest/bin/jest.js apps/frontend/src/components/__tests__/decision-card.test.tsx` *(fails: Configuring Next.js via 'next.config.ts' is not supported)*
- `node_modules/.pnpm/turbo@2.5.6/node_modules/turbo/bin/turbo test` *(fails: @smm-architect/ui#build exited (1))*
- `make test-security` *(fails: missing RLS policies)*

------
https://chatgpt.com/codex/tasks/task_e_68b99f5f163c832bb28492234330b34f
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add a new DecisionCard component with accessible markup and enable unit tests for rendering, actions, and expanded details. Also improves currency formatting and time-remaining assertions.

- **New Features**
  - DecisionCard (role="article") showing proposal details, risk badges, expiry, and loading-disabled actions.
  - Expandable details: cost breakdown with two-decimal currency and a provenance sources toggle.
  - Action handlers for Approve, Reject, and Request Changes, including feedback text passed to the callback.
  - Tests enabled and updated for roles, time-remaining pattern, currency formatting, score colors, and action flows.

<!-- End of auto-generated description by cubic. -->

