### PR TITLE
feat: add health endpoints and probes

### DIFF
--- a/infrastructure/kubernetes/10-smm-architect-service.yaml
+++ b/infrastructure/kubernetes/10-smm-architect-service.yaml
@@ -59,7 +59,7 @@ spec:
           failureThreshold: 3
         readinessProbe:
           httpGet:
-            path: /ready
+            path: /health
             port: http
           initialDelaySeconds: 10
           periodSeconds: 5

--- a/infrastructure/kubernetes/11-toolhub-service.yaml
+++ b/infrastructure/kubernetes/11-toolhub-service.yaml
@@ -59,7 +59,7 @@ spec:
           failureThreshold: 3
         readinessProbe:
           httpGet:
-            path: /ready
+            path: /health
             port: http
           initialDelaySeconds: 10
           periodSeconds: 5

--- a/services/agents/src/server.ts
+++ b/services/agents/src/server.ts
@@ -1,0 +1,31 @@
+import express from 'express';
+import cors from 'cors';
+import helmet from 'helmet';
+import { createHealthCheckMiddleware } from '../../shared/health-check';
+
+const app = express();
+const PORT = process.env.PORT || 3004;
+
+app.use(helmet());
+app.use(cors());
+app.use(express.json());
+
+const { routes } = createHealthCheckMiddleware({
+  serviceName: 'agents-service',
+  version: process.env.npm_package_version || '1.0.0',
+  dependencies: {}
+});
+
+app.get('/health', routes.health);
+app.get('/ready', routes.ready);
+app.get('/live', routes.live);
+
+if (require.main === module) {
+  app.listen(PORT, () => {
+    // eslint-disable-next-line no-console
+    console.log(`Agents service listening on port ${PORT}`);
+  });
+}
+
+export default app;
+export { app };

--- a/services/agents/tests/health.test.ts
+++ b/services/agents/tests/health.test.ts
@@ -1,0 +1,11 @@
+import request from 'supertest';
+import { describe, it, expect } from '@jest/globals';
+import app from '../src/server';
+
+describe('Agents Service Health', () => {
+  it('should return healthy status', async () => {
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('healthy');
+  });
+});

--- a/services/model-router/test/health.test.ts
+++ b/services/model-router/test/health.test.ts
@@ -1,0 +1,11 @@
+import request from 'supertest';
+import { describe, it, expect } from '@jest/globals';
+import { app } from '../src/index';
+
+describe('Model Router Health Endpoint', () => {
+  it('returns healthy status', async () => {
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('healthy');
+  });
+});

--- a/services/publisher/tests/health.test.ts
+++ b/services/publisher/tests/health.test.ts
@@ -1,0 +1,11 @@
+import request from 'supertest';
+import { describe, it, expect } from '@jest/globals';
+import app from '../src/server';
+
+describe('Publisher Service Health', () => {
+  it('should report healthy status', async () => {
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBeDefined();
+  });
+});

--- a/services/smm-architect/tests/health.test.ts
+++ b/services/smm-architect/tests/health.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from '@jest/globals';
+import { health } from '../src/main';
+
+describe('SMM Architect Health Endpoint', () => {
+  it('returns healthy status', async () => {
+    const res = await health();
+    expect(res.status).toBe('healthy');
+  });
+});


### PR DESCRIPTION
## Summary
- expose express health endpoints for agents service
- add health endpoint tests across services
- point k8s probes at unified /health paths

## Testing
- `node node_modules/jest/bin/jest.js` *(smm-architect service failed: Cannot find module 'ajv-formats')*
- `node node_modules/jest/bin/jest.js --config jest.config.js` *(toolhub service failed: validation and authorization errors)*
- `node node_modules/jest/bin/jest.js` *(model-router service failed: TypeScript compile errors)*
- `node node_modules/jest/bin/jest.js` *(publisher service failed: SyntaxError: Cannot use import statement outside a module)*
- `node node_modules/jest/bin/jest.js tests/health.test.ts` *(agents service failed: Cannot find module 'ioredis')*

------
https://chatgpt.com/codex/tasks/task_e_68b99f5ac04c832bbf0908468dc568e1
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Standardized health endpoints across services and updated Kubernetes readiness probes to use /health for consistent monitoring. Added basic tests to verify healthy responses.

- **New Features**
  - Agents service: Express server exposes /health, /ready, and /live via shared middleware.
  - Added /health tests for agents, model-router, publisher, and smm-architect.
  - Switched smm-architect and toolhub readinessProbe paths from /ready to /health.

<!-- End of auto-generated description by cubic. -->

