### PR TITLE
feat: add cloud log providers

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,8 @@
     "@types/js-yaml": "^4.0.9",
     "artillery": "^2.0.4",
     "axios": "^1.6.2",
+    "@aws-sdk/client-cloudwatch-logs": "^3.645.0",
+    "@google-cloud/logging": "^11.0.0",
     "fast-check": "^3.15.0",
     "js-yaml": "^4.1.0",
     "prom-client": "^15.1.0"

--- a/tests/unit/audit-log-streamer-cloud.test.ts
+++ b/tests/unit/audit-log-streamer-cloud.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, jest, afterEach } from '@jest/globals';
+import { AuditLogStreamer, SIEMConfig } from '../../services/shared/security/audit-log-streamer';
+
+// Mock AWS CloudWatch Logs SDK
+const mockCloudWatchSend = jest.fn().mockResolvedValue({ nextSequenceToken: 'token' });
+class PutLogEventsCommand {
+  input: any;
+  constructor(input: any) {
+    this.input = input;
+  }
+}
+jest.mock('@aws-sdk/client-cloudwatch-logs', () => ({
+  CloudWatchLogsClient: jest.fn(() => ({ send: mockCloudWatchSend })),
+  PutLogEventsCommand
+}));
+
+// Mock Google Cloud Logging SDK
+const mockGcpWrite = jest.fn().mockResolvedValue(undefined);
+const mockEntry = jest.fn((meta: any, data: any) => ({ meta, data }));
+const mockLog = jest.fn(() => ({ write: mockGcpWrite, entry: mockEntry }));
+jest.mock('@google-cloud/logging', () => ({
+  Logging: jest.fn(() => ({ log: mockLog }))
+}));
+
+// Mock internal logger used by audit log streamer
+jest.mock('../../services/shared/utils/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn()
+  }
+}), { virtual: true });
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('AuditLogStreamer cloud providers', () => {
+  it('sends events to AWS CloudWatch when enabled', async () => {
+    const config: SIEMConfig = {
+      enabled: true,
+      buffer_size: 1,
+      flush_interval_ms: 1000,
+      retry_attempts: 0,
+      retry_delay_ms: 0,
+      destinations: [
+        {
+          name: 'cw',
+          type: 'aws_cloudwatch',
+          enabled: true,
+          config: {
+            region: 'us-east-1',
+            logGroupName: 'group',
+            logStreamName: 'stream'
+          }
+        }
+      ]
+    };
+
+    const streamer = new AuditLogStreamer(config);
+    await streamer.recordEvent({
+      event_type: 'test',
+      action: 'do',
+      outcome: 'success',
+      target: { resource_type: 'unit' },
+      details: {},
+      actor: {},
+      source: 'test-service'
+    });
+    await streamer.shutdown();
+
+    expect(mockCloudWatchSend).toHaveBeenCalled();
+    const callArg = mockCloudWatchSend.mock.calls[0][0] as any;
+    expect(callArg.input.logEvents).toHaveLength(1);
+  });
+
+  it('sends events to GCP Logging when enabled', async () => {
+    const config: SIEMConfig = {
+      enabled: true,
+      buffer_size: 1,
+      flush_interval_ms: 1000,
+      retry_attempts: 0,
+      retry_delay_ms: 0,
+      destinations: [
+        {
+          name: 'gcp',
+          type: 'gcp_logging',
+          enabled: true,
+          config: {
+            projectId: 'test',
+            logName: 'audit'
+          }
+        }
+      ]
+    };
+
+    const streamer = new AuditLogStreamer(config);
+    await streamer.recordEvent({
+      event_type: 'test',
+      action: 'do',
+      outcome: 'success',
+      target: { resource_type: 'unit' },
+      details: {},
+      actor: {},
+      source: 'test-service'
+    });
+    await streamer.shutdown();
+
+    expect(mockLog).toHaveBeenCalledWith('audit');
+    expect(mockGcpWrite).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add AWS CloudWatch and GCP Logging clients for audit log streaming
- expose env toggles for cloud log destinations
- cover cloud integrations with unit tests

## Testing
- `npx jest tests/unit/audit-log-streamer-cloud.test.ts`
- `npm test` *(fails: command (/workspace/smm-architect/services/smm-architect) pnpm run build exited with code 1)*


------
https://chatgpt.com/codex/tasks/task_e_68b99f512dd4832bb9bc90ae09004ab7
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add AWS CloudWatch Logs and GCP Cloud Logging to the audit log streamer to send audit events to cloud providers. Controlled by env flags and covered by unit tests.

- **New Features**
  - Lazy-init and cache AWS/GCP logging clients per destination; CloudWatch tracks nextSequenceToken.
  - Added default destinations to the SIEM config, enabled via CLOUDWATCH_ENABLED and GCP_LOGGING_ENABLED; configuration via env (region/group/stream, project/log, credentials).
  - Unit tests validate both providers.

- **Dependencies**
  - Added @aws-sdk/client-cloudwatch-logs and @google-cloud/logging.

<!-- End of auto-generated description by cubic. -->

