### PR TITLE
feat: add s3 archival for ttl job

### DIFF
--- a/services/smm-architect/package.json
+++ b/services/smm-architect/package.json
@@ -30,7 +30,8 @@
     "uuid": "^9.0.0",
     "date-fns": "^2.30.0",
     "@sentry/node": "^7.99.0",
-    "@sentry/profiling-node": "^7.99.0"
+    "@sentry/profiling-node": "^7.99.0",
+    "@aws-sdk/client-s3": "^3.445.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",


### PR DESCRIPTION
## Summary
- implement S3 archival with compressed data for TTL job
- add AWS credential configuration
- include @aws-sdk/client-s3 dependency

## Testing
- `make test` *(fails: turbo not found)*
- `make test-security` *(fails: RLS policy requirements unmet)*

------
https://chatgpt.com/codex/tasks/task_e_68b99f4e77dc832bb86f328bc6277dea
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds S3 archival to the TTL job. Expired workspaces are gzipped and uploaded to S3 for long‑term storage.

- New Features
  - Uploads compressed JSON to s3://<bucket>/archived-workspaces/<workspace_id>/<timestamp>.json.gz.
  - Uses AWS SDK v3 S3 client with region and optional explicit credentials.
  - Masks secrets in logs and verifies uploads with HeadObject. Returns the S3 URL.

- Migration
  - Set ARCHIVE_S3_BUCKET and AWS_REGION. Optionally set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY if not using instance role.
  - Ensure IAM allows s3:PutObject and s3:HeadObject on the bucket path.
  - archiveToS3 defaults to true; set to false to skip S3 uploads.

<!-- End of auto-generated description by cubic. -->

