### PR TITLE
docs: add vault credential workflows and production setup automation

### DIFF
--- a/.github/workflows/setup-production.yml
+++ b/.github/workflows/setup-production.yml
@@ -1,0 +1,38 @@
+name: Production Environment Setup
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+
+jobs:
+  setup-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8.15.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'pnpm'
+
+      - name: Configure Pulumi
+        uses: pulumi/actions@v4
+        with:
+          command: pulumi version
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+
+      - name: Run production setup script
+        run: tools/scripts/setup-production-environment.sh
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+          VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+          VAULT_TOKEN: ${{ secrets.VAULT_TOKEN }}

--- a/docs/vault-credential-workflows.md
+++ b/docs/vault-credential-workflows.md
@@ -1,0 +1,55 @@
+# Vault Credential Workflows
+
+This guide documents how SMM Architect services interact with HashiCorp Vault for secret management. It covers token rotation, secret retrieval and cross-service usage patterns.
+
+## Overview
+
+SMM Architect relies on HashiCorp Vault to store sensitive configuration such as API keys and database credentials. Each service authenticates with Vault using a short-lived token and retrieves only the secrets it needs.
+
+## Token Issuance and Rotation
+
+1. **Initial Authentication** – Services authenticate using a bootstrap token or cloud IAM role to obtain a scoped Vault token.
+2. **Ephemeral Tokens** – The `VaultTokenIssuer` service issues time-bound tokens for agents and microservices.
+3. **Automatic Rotation** – Tokens are renewed before expiration and revoked when no longer needed.
+
+### Verifying Token Rotation
+
+Use the `scripts/verify-vault-credentials.sh` helper to issue a token, fetch a secret and verify rotation:
+
+```bash
+./scripts/verify-vault-credentials.sh my-app-role secret/data/api
+```
+
+The script will:
+
+1. Authenticate using the provided role.
+2. Read the requested secret path.
+3. Rotate the token and verify that the new token can still access the secret.
+
+## Secret Retrieval Across Services
+
+Each service uses the shared `VaultClient` (`services/shared/vault-client.js`) to retrieve secrets.
+
+Example usage:
+
+```ts
+import { VaultClient } from '../shared/vault-client';
+
+const vault = new VaultClient({
+  url: process.env.VAULT_ADDR!,
+  token: process.env.VAULT_TOKEN!,
+  namespace: process.env.VAULT_NAMESPACE,
+});
+
+const dbPassword = await vault.getSecret('secret/data/db').then(r => r.data.password);
+```
+
+Secrets are namespaced by tenant and service. Policies enforce least privilege and all accesses are auditable.
+
+## Operational Considerations
+
+- **Audit Logging** – All Vault interactions are logged and shipped to the central SIEM.
+- **Revocation** – Tokens are revoked on service shutdown and during incident response.
+- **Health Checks** – Services call `vaultClient.healthCheck()` during startup to validate connectivity.
+
+For more details on security testing and infrastructure setup, see `docs/production-readiness-guide.md` and `tools/scripts/setup-production-environment.sh`.

--- a/scripts/verify-vault-credentials.sh
+++ b/scripts/verify-vault-credentials.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Helper script to verify Vault token issuance, rotation and secret retrieval
+# Usage: ./scripts/verify-vault-credentials.sh <role> <secret-path>
+
+set -euo pipefail
+
+ROLE="${1:-}"           # AppRole or auth role to login with
+SECRET_PATH="${2:-}"    # Secret path to read, e.g. secret/data/api
+VAULT_ADDR="${VAULT_ADDR:-http://localhost:8200}"
+
+if [[ -z "$ROLE" || -z "$SECRET_PATH" ]]; then
+  echo "Usage: $0 <role> <secret-path>" >&2
+  exit 1
+fi
+
+log() { echo "[vault-check] $1"; }
+
+log "Logging in to Vault using role $ROLE"
+LOGIN_RESP=$(curl -s --fail -X POST "$VAULT_ADDR/v1/auth/$ROLE/login" || exit 1)
+TOKEN=$(echo "$LOGIN_RESP" | jq -r '.auth.client_token')
+
+if [[ -z "$TOKEN" || "$TOKEN" == "null" ]]; then
+  echo "Failed to retrieve token" >&2
+  exit 1
+fi
+
+log "Reading secret at $SECRET_PATH"
+SECRET=$(curl -s --fail -H "X-Vault-Token: $TOKEN" "$VAULT_ADDR/v1/$SECRET_PATH" || exit 1)
+log "Secret data: $(echo "$SECRET" | jq -c '.data.data')"
+
+log "Rotating token"
+ROTATE_RESP=$(curl -s --fail -X POST -H "X-Vault-Token: $TOKEN" "$VAULT_ADDR/v1/auth/token/renew" || exit 1)
+NEW_TOKEN=$(echo "$ROTATE_RESP" | jq -r '.auth.client_token')
+
+if [[ -z "$NEW_TOKEN" || "$NEW_TOKEN" == "null" ]]; then
+  echo "Failed to rotate token" >&2
+  exit 1
+fi
+
+log "Reading secret with rotated token"
+SECOND_READ=$(curl -s --fail -H "X-Vault-Token: $NEW_TOKEN" "$VAULT_ADDR/v1/$SECRET_PATH" || exit 1)
+log "Secret read after rotation: $(echo "$SECOND_READ" | jq -c '.data.data')"
+
+log "Vault credential workflow verified"

--- a/tools/scripts/setup-production-environment.sh
+++ b/tools/scripts/setup-production-environment.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# SMM Architect production environment setup and deployment helper
+# Provisions infrastructure, builds services and deploys to production
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+log() { echo -e "\033[0;34m[setup]\033[0m $1"; }
+
+check_prerequisites() {
+  log "Checking prerequisites"
+  for tool in node pnpm pulumi docker; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+      echo "$tool not found" >&2
+      exit 1
+    fi
+  done
+}
+
+install_dependencies() {
+  log "Installing dependencies"
+  cd "$PROJECT_ROOT"
+  pnpm install --frozen-lockfile
+}
+
+provision_infrastructure() {
+  log "Provisioning infrastructure with Pulumi"
+  cd "$PROJECT_ROOT/infrastructure/base/pulumi"
+  pulumi stack select production || pulumi stack init production
+  pulumi up --yes
+}
+
+build_services() {
+  log "Building services"
+  cd "$PROJECT_ROOT"
+  pnpm run build
+}
+
+deploy_services() {
+  log "Deploying services via docker-compose.prod.yml"
+  cd "$PROJECT_ROOT"
+  docker compose -f docker-compose.prod.yml up -d
+}
+
+check_prerequisites
+install_dependencies
+provision_infrastructure
+build_services
+deploy_services
+
+log "Production environment setup complete"


### PR DESCRIPTION
## Summary
- document Vault token rotation and secret retrieval
- add script to verify Vault credentials and rotation
- add production setup script and CI workflow

## Testing
- `make test` *(fails: encore: not found)*
- `make test-security` *(fails: target error)*

------
https://chatgpt.com/codex/tasks/task_e_68b99f4bf344832b81250cf46e7880f7
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds Vault credential workflow docs and automation. Introduces a token verification script and a production setup script wired into CI for one-click setup and deploy.

- **New Features**
  - docs/vault-credential-workflows.md: token issuance/rotation, secret reads, ops notes.
  - scripts/verify-vault-credentials.sh: login, read secret, renew token, re-read.
  - tools/scripts/setup-production-environment.sh: install deps, Pulumi up (production), build, docker-compose deploy.
  - .github/workflows/setup-production.yml: runs setup on push to main or manual dispatch; uses PULUMI_ACCESS_TOKEN, VAULT_ADDR, VAULT_TOKEN.

- **Migration**
  - Add GitHub secrets: PULUMI_ACCESS_TOKEN, VAULT_ADDR, VAULT_TOKEN.
  - Optionally run scripts/verify-vault-credentials.sh <role> <secret-path> before deploy.

<!-- End of auto-generated description by cubic. -->

