### PR TITLE
feat: fetch tenant db secrets from vault

### DIFF
--- a/docs/vault-policies-and-rotation.md
+++ b/docs/vault-policies-and-rotation.md
@@ -1,0 +1,28 @@
+# Vault Policies and Secret Rotation
+
+This document outlines the required HashiCorp Vault policies and the rotation process for tenant database credentials.
+
+## Required Policies
+
+Each tenant receives a dedicated KV v2 mount at `tenant-<TENANT_ID>`. The following policy grants the tenant service account full access to its own path:
+
+```hcl
+path "tenant-<TENANT_ID>/data/*" {
+  capabilities = ["create", "read", "update", "delete", "list"]
+}
+path "tenant-<TENANT_ID>/metadata/*" {
+  capabilities = ["list"]
+}
+```
+
+Assign this policy to the Kubernetes auth role used by the tenant's service account.
+
+## Secret Rotation
+
+Database passwords are stored in Vault and synchronized to Kubernetes using the External Secrets Operator. To rotate a password:
+
+1. Update the secret value in Vault at `tenant-<TENANT_ID>/database`.
+2. External Secrets Operator detects the change and updates the Kubernetes `Secret` resource.
+3. A rolling restart of dependent workloads picks up the new credentials.
+
+Regular rotation is recommended. If the secret is missing, deployment will fail to ensure that all credentials are present before provisioning.


### PR DESCRIPTION
## Summary
- fetch tenant database passwords directly from Vault
- document Vault policies and rotation workflow
- validate secrets exist before provisioning

## Testing
- `make test` *(fails: turbo: not found)*
- `make test-security` *(fails: RLS violations in migrations)*

------
https://chatgpt.com/codex/tasks/task_e_68b99f47f94c832bb5bbd47fbfdcb66d
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fetch tenant database passwords from Vault during provisioning and block deploys if the secret is missing. This replaces the placeholder value and improves rotation safety.

- **New Features**
  - Read the DB password from Vault at tenant-<TENANT_ID>/database via Pulumi and populate the Kubernetes Secret.
  - Validate that the password key exists; throw to stop provisioning if absent.
  - Added docs for required Vault policies and the rotation workflow.

- **Migration**
  - Create Vault secret tenant-<TENANT_ID>/database with key password.
  - Grant the tenant service account access using the policy in docs/vault-policies-and-rotation.md.
  - If using External Secrets Operator, ensure it watches this secret for rotation.

<!-- End of auto-generated description by cubic. -->

