### PR TITLE
chore: update env example placeholders

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,26 @@
 # Sentry Configuration
-SENTRY_DSN=https://02a82d6e1d09e631f5ef7083e197c841@o4509899378786304.ingest.de.sentry.io/4509899558879312
-NEXT_PUBLIC_SENTRY_DSN=https://02a82d6e1d09e631f5ef7083e197c841@o4509899378786304.ingest.de.sentry.io/4509899558879312
+# Replace with your Sentry DSN. See https://docs.sentry.io/
+SENTRY_DSN=https://examplePublicKey@o0.ingest.sentry.io/0
+NEXT_PUBLIC_SENTRY_DSN=https://examplePublicKey@o0.ingest.sentry.io/0
 SENTRY_ENABLED=true
 
 # Application Configuration
 NODE_ENV=development
 PORT=3000
+
+# Database Configuration
+# PostgreSQL connection string
+DATABASE_URL=postgresql://user:password@localhost:5432/smm_architect
+
+# Cache Configuration
+# Redis connection URL
+REDIS_URL=redis://localhost:6379
+
+# Vault Configuration
+# Address of the Vault server
+VAULT_ADDR=https://localhost:8200
+# Token used to authenticate with Vault
+VAULT_TOKEN=change-me
 
 # Optional: Sentry Release Tracking
 npm_package_version=1.0.0


### PR DESCRIPTION
## Summary
- replace real Sentry DSNs with placeholders
- document database, redis, and vault env vars in `.env.example`

## Testing
- `make test` *(fails: Cannot find module '@agentuity/sdk')*
- `make test-security` *(fails: migration RLS policy requirements not satisfied)*

------
https://chatgpt.com/codex/tasks/task_e_68b99f424570832b99ef4b3f148d741d
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Replaced real Sentry DSNs with placeholders and expanded .env.example to document Database (DATABASE_URL), Redis (REDIS_URL), and Vault (VAULT_ADDR, VAULT_TOKEN) variables. This removes hardcoded secrets and makes local setup clearer.

<!-- End of auto-generated description by cubic. -->

