### PR TITLE
Add proprietary license and update README references

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,9 @@
+SMM Architect Proprietary License
+
+Copyright (c) 2025 SMM Architect Team. All rights reserved.
+
+This software and associated documentation files (the "Software") are proprietary and confidential. Unauthorized copying, modification, distribution, or use of the Software, in whole or in part, is strictly prohibited without the express prior written permission of the SMM Architect Team.
+
+The Software is provided "as is" without warranty of any kind, express or implied, including but not limited to warranties of merchantability, fitness for a particular purpose, and non-infringement.
+
+For licensing inquiries, please contact dev@smmarchitect.com.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SMM Architect
 
 [![CI Status](https://github.com/yourorg/smm-architect/workflows/CI/badge.svg)](https://github.com/yourorg/smm-architect/actions)
-[![License](https://img.shields.io/badge/license-Proprietary-red.svg)](LICENSE)
+[![License](https://img.shields.io/badge/license-Proprietary-red.svg)](./LICENSE)
 [![Version](https://img.shields.io/badge/version-1.0.0-blue.svg)](CHANGELOG.md)
 [![Status](https://img.shields.io/badge/status-Production%20Ready-brightgreen.svg)](AGENTS.md)
 
@@ -453,7 +453,7 @@ See `examples/workspace-contract.icblabs.json` for a complete example workspace 
 
 ## 📄 License
 
-This project is proprietary software. See [LICENSE](LICENSE) for details.
+This project is proprietary software. See [LICENSE](./LICENSE) for details.
 
 ## 🙋‍♀️ Support
 


### PR DESCRIPTION
## Summary
- add proprietary license
- clarify README links to license

## Testing
- `make test` *(fails: @smm-architect/ui:build exited 1)*
- `make test-security` *(fails: RLS violations in migrations)*

------
https://chatgpt.com/codex/tasks/task_e_68b99f3ba310832ba89d8002c809796e
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds the SMM Architect Proprietary License and updates README links to reference ./LICENSE. This clarifies licensing and fixes link paths in the badge and License section.

<!-- End of auto-generated description by cubic. -->

