### PR TITLE
chore: externalize postgres credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,15 @@ SENTRY_DSN=https://02a82d6e1d09e631f5ef7083e197c841@o4509899378786304.ingest.de.
 NEXT_PUBLIC_SENTRY_DSN=https://02a82d6e1d09e631f5ef7083e197c841@o4509899378786304.ingest.de.sentry.io/4509899558879312
 SENTRY_ENABLED=true
 
+# Database Configuration
+POSTGRES_DB=smm_architect
+POSTGRES_USER=smm_user
+POSTGRES_PASSWORD=changeme
+POSTGRES_MULTIPLE_DATABASES=smm_architect,smm_test
+POSTGRES_TEST_DB=smm_test
+POSTGRES_TEST_USER=smm_test
+POSTGRES_TEST_PASSWORD=changeme
+
 # Application Configuration
 NODE_ENV=development
 PORT=3000

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -12,12 +12,17 @@ services:
     environment:
       - NODE_ENV=production
       - PORT=4000
-      - DATABASE_URL=${DATABASE_URL}
-      - REDIS_URL=${REDIS_URL}
+      - DATABASE_URL_FILE=/run/secrets/database_url
+      - REDIS_URL_FILE=/run/secrets/redis_url
       - VAULT_URL=${VAULT_URL}
-      - VAULT_TOKEN=${VAULT_TOKEN}
-      - SENTRY_DSN=${SENTRY_DSN}
+      - VAULT_TOKEN_FILE=/run/secrets/vault_token
+      - SENTRY_DSN_FILE=/run/secrets/sentry_dsn
       - SENTRY_ENVIRONMENT=production
+    secrets:
+      - database_url
+      - redis_url
+      - vault_token
+      - sentry_dsn
     volumes:
       - smm_logs:/app/logs
     networks:
@@ -51,13 +56,19 @@ services:
     environment:
       - NODE_ENV=production
       - PORT=3001
-      - DATABASE_URL=${DATABASE_URL}
-      - REDIS_URL=${REDIS_URL}
+      - DATABASE_URL_FILE=/run/secrets/database_url
+      - REDIS_URL_FILE=/run/secrets/redis_url
       - VAULT_URL=${VAULT_URL}
-      - VAULT_TOKEN=${VAULT_TOKEN}
-      - SENTRY_DSN=${SENTRY_DSN}
+      - VAULT_TOKEN_FILE=/run/secrets/vault_token
+      - SENTRY_DSN_FILE=/run/secrets/sentry_dsn
       - SENTRY_ENVIRONMENT=production
-      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - OPENAI_API_KEY_FILE=/run/secrets/openai_api_key
+    secrets:
+      - database_url
+      - redis_url
+      - vault_token
+      - sentry_dsn
+      - openai_api_key
     volumes:
       - toolhub_logs:/app/logs
     networks:
@@ -91,8 +102,10 @@ services:
       - NODE_ENV=production
       - NEXT_PUBLIC_API_URL=${API_URL}
       - NEXT_PUBLIC_TOOLHUB_URL=${TOOLHUB_URL}
-      - SENTRY_DSN=${SENTRY_DSN}
+      - SENTRY_DSN_FILE=/run/secrets/sentry_dsn
       - SENTRY_ENVIRONMENT=production
+    secrets:
+      - sentry_dsn
     networks:
       - smm-network
     restart: unless-stopped
@@ -174,6 +187,19 @@ volumes:
     driver: local
   toolhub_logs:
     driver: local
+
+# Secrets
+secrets:
+  database_url:
+    external: true
+  redis_url:
+    external: true
+  vault_token:
+    external: true
+  sentry_dsn:
+    external: true
+  openai_api_key:
+    external: true
 
 # Networks
 networks:

--- a/docker-compose.secure.yml
+++ b/docker-compose.secure.yml
@@ -7,10 +7,12 @@ services:
     container_name: smm-postgres
     restart: unless-stopped
     environment:
-      POSTGRES_DB: smm_architect
-      POSTGRES_USER: smm_user
+      POSTGRES_DB_FILE: /run/secrets/postgres_db
+      POSTGRES_USER_FILE: /run/secrets/postgres_user
       POSTGRES_PASSWORD_FILE: /run/secrets/postgres_password
     secrets:
+      - postgres_db
+      - postgres_user
       - postgres_password
     volumes:
       - postgres_data:/var/lib/postgresql/data:rw
@@ -20,7 +22,7 @@ services:
     networks:
       - smm-network
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U smm_user -d smm_architect"]
+      test: ["CMD-SHELL", "pg_isready -U $$(cat /run/secrets/postgres_user) -d $$(cat /run/secrets/postgres_db)"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -48,7 +50,7 @@ services:
     restart: unless-stopped
     command: >
       redis-server
-      --requirepass "${REDIS_PASSWORD}"
+      --requirepass "$${REDIS_PASSWORD}"
       --maxmemory 256mb
       --maxmemory-policy allkeys-lru
       --save 60 1
@@ -362,6 +364,10 @@ volumes:
 secrets:
   postgres_password:
     file: ./secrets/postgres_password.txt
+  postgres_user:
+    file: ./secrets/postgres_user.txt
+  postgres_db:
+    file: ./secrets/postgres_db.txt
   redis_password:
     file: ./secrets/redis_password.txt
   database_url:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,17 +6,17 @@ services:
     image: postgres:14-alpine
     container_name: smm-postgres
     environment:
-      POSTGRES_DB: smm_architect
-      POSTGRES_USER: smm_user
-      POSTGRES_PASSWORD: smm_password
-      POSTGRES_MULTIPLE_DATABASES: smm_architect,smm_test
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_MULTIPLE_DATABASES: ${POSTGRES_MULTIPLE_DATABASES}
     ports:
       - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./services/smm-architect/migrations:/docker-entrypoint-initdb.d
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U smm_user -d smm_architect"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -49,7 +49,7 @@ services:
     environment:
       - NODE_ENV=development
       - PORT=4000
-      - DATABASE_URL=postgresql://smm_user:smm_password@postgres:5432/smm_architect
+      - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
       - REDIS_URL=redis://redis:6379
       - VAULT_URL=http://vault:8200
       - SENTRY_DSN=${SENTRY_DSN}
@@ -75,7 +75,7 @@ services:
     environment:
       - NODE_ENV=development
       - PORT=3001
-      - DATABASE_URL=postgresql://smm_user:smm_password@postgres:5432/smm_architect
+      - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
       - REDIS_URL=redis://redis:6379
       - VAULT_URL=http://vault:8200
       - SENTRY_DSN=${SENTRY_DSN}
@@ -178,9 +178,9 @@ services:
     image: postgres:14-alpine
     container_name: smm-postgres-test
     environment:
-      POSTGRES_DB: smm_test
-      POSTGRES_USER: smm_test
-      POSTGRES_PASSWORD: smm_test
+      POSTGRES_DB: ${POSTGRES_TEST_DB}
+      POSTGRES_USER: ${POSTGRES_TEST_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_TEST_PASSWORD}
     ports:
       - "5433:5432"
     volumes:


### PR DESCRIPTION
## Summary
- reference Postgres credentials via environment variables in development compose file
- document required database env vars
- secure production compose files by sourcing secrets

## Testing
- `make test` *(fails: command exited with error 1)*
- `make test-security` *(fails: RLS policy violations)*

------
https://chatgpt.com/codex/tasks/task_e_68b99d49600c832b9dd97d759da30393
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Move Postgres credentials to environment variables in development and Docker secrets in production. This removes hardcoded credentials in compose files and improves security.

- **Refactors**
  - docker-compose.yml: use POSTGRES_* env vars and build DATABASE_URL from them (including test DB); healthchecks read vars.
  - docker-compose.prod.yml: switch to *_FILE envs for DATABASE_URL, REDIS_URL, VAULT_TOKEN, SENTRY_DSN, OPENAI_API_KEY and mount corresponding Docker secrets.
  - docker-compose.secure.yml: read POSTGRES_DB/USER/PASSWORD from secrets; update healthcheck to use secrets; fix Redis requirepass to read from env.

- **Migration**
  - Dev: copy .env.example to .env and set POSTGRES_DB, POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_MULTIPLE_DATABASES, and test DB vars.
  - Prod: ensure these Docker secrets exist and are populated: database_url, redis_url, vault_token, sentry_dsn, openai_api_key. For secure compose, also create postgres_db, postgres_user, postgres_password, and redis_password.

<!-- End of auto-generated description by cubic. -->

