### PR TITLE
docs: add vault credential workflow and production deployment automation

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -1,0 +1,30 @@
+name: Production Deployment
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+    tags: [ 'v*' ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Install Pulumi CLI
+        uses: pulumi/actions@v4
+        with:
+          command: version
+
+      - name: Run production setup
+        env:
+          VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+          VAULT_TOKEN: ${{ secrets.VAULT_TOKEN }}
+        run: ./tools/scripts/setup-production-env.sh

--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ curl -X POST http://localhost:4000/workspaces/ws-example-001/simulate \
 
 - **[Local Development](docs/development.md)** - Setting up development environment
 - **[Production Deployment](docs/deployment.md)** - Kubernetes and cloud deployment
-- **[Vault Configuration](docs/vault-setup.md)** - Secrets management setup
+ - **[Vault Credential Workflows](docs/vault-credential-workflows.md)** - Secrets management setup and token rotation
 
 ## 🧪 Testing
 

--- a/docs/vault-credential-workflows.md
+++ b/docs/vault-credential-workflows.md
@@ -1,0 +1,63 @@
+# Vault Credential Workflows
+
+This guide explains how SMM Architect services obtain and rotate Vault tokens and retrieve secrets securely across the platform.
+
+## Token Issuance and Revocation
+
+Agents request scoped tokens from the `VaultTokenIssuer`. Each execution issues a short‑lived token and revokes it when finished to limit exposure:
+
+```ts
+// services/agents/src/executor.ts
+const vaultToken = await this.vaultTokenIssuer.issueAgentToken(
+  request.agentType,
+  request.workspaceId
+);
+// ...
+await this.vaultTokenIssuer.revokeToken(vaultToken);
+```
+
+## Token Rotation
+
+The shared `VaultClient` automatically renews tokens before expiration. Tokens can also be renewed manually when running long‑lived tasks:
+
+```ts
+// services/shared/vault-client.ts
+async renewSelf(increment?: string): Promise<VaultAuthResponse> {
+  const payload = increment ? { increment } : {};
+  const response = await this.client.post('/v1/auth/token/renew-self', payload);
+  const auth = response.data.auth;
+  this.tokenExpiry = new Date(Date.now() + (auth.lease_duration * 1000));
+  return auth;
+}
+```
+
+The client exposes `shouldRenewToken()` to determine when renewal is required (within five minutes of expiry).
+
+## Secret Retrieval
+
+Services fetch secrets using the shared client. The client validates tokens and performs authenticated KV reads:
+
+```ts
+const secret = await vaultClient.readKVSecret(`agentuity/${tenantId}/webhook_key`);
+```
+
+## Verification Workflow
+
+1. **Create a short‑lived token**
+   ```bash
+   VAULT_TOKEN=$(vault token create -ttl=1h -format=json | jq -r '.auth.client_token')
+   ```
+2. **Use the token to retrieve a secret**
+   ```bash
+   VAULT_TOKEN="$VAULT_TOKEN" vault kv get secret/workspaces/sample/toolhub-api-key
+   ```
+3. **Renew the token before expiry**
+   ```bash
+   VAULT_TOKEN="$VAULT_TOKEN" vault token renew
+   ```
+4. **Revoke the token when finished**
+   ```bash
+   vault token revoke "$VAULT_TOKEN"
+   ```
+
+These steps verify token rotation and secret retrieval across services while ensuring credentials are short‑lived and revocable.

--- a/tools/scripts/setup-production-env.sh
+++ b/tools/scripts/setup-production-env.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Automated production environment setup and deployment
+# Usage: ./setup-production-env.sh [stack]
+
+set -euo pipefail
+
+STACK="${1:-production}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log() { echo -e "${BLUE}[INFO]${NC} $1"; }
+success() { echo -e "${GREEN}[SUCCESS]${NC} $1"; }
+warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+error() { echo -e "${RED}[ERROR]${NC} $1"; }
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || { error "$1 is required"; exit 1; }
+}
+
+check_prereqs() {
+  log "Validating required tools"
+  for cmd in docker vault pulumi; do
+    require_cmd "$cmd"
+  done
+  [ -n "${VAULT_ADDR:-}" ] || { error "VAULT_ADDR not set"; exit 1; }
+  [ -n "${VAULT_TOKEN:-}" ] || { error "VAULT_TOKEN not set"; exit 1; }
+}
+
+deploy_infrastructure() {
+  log "Provisioning infrastructure with Pulumi ($STACK)"
+  pulumi stack select "$STACK" || pulumi stack init "$STACK"
+  pulumi up --yes
+}
+
+deploy_services() {
+  log "Deploying services with docker-compose"
+  docker-compose -f "$PROJECT_ROOT/docker-compose.prod.yml" up -d --build
+}
+
+verify_vault() {
+  log "Verifying Vault token rotation and secret retrieval"
+  TOKEN=$(vault token create -ttl=1h -format=json | jq -r '.auth.client_token')
+  VAULT_TOKEN="$TOKEN" vault kv get secret/health-check >/dev/null 2>&1 || warn "health-check secret missing"
+  VAULT_TOKEN="$TOKEN" vault token renew >/dev/null
+  vault token revoke "$TOKEN" >/dev/null
+  success "Vault token rotation verified"
+}
+
+check_prereqs
+deploy_infrastructure
+deploy_services
+verify_vault
+
+success "Production environment setup complete"


### PR DESCRIPTION
## Summary
- document Vault token issuance, rotation, and secret retrieval across services
- automate production environment setup with script verifying Vault token rotation
- add CI workflow to trigger production deployment script

## Testing
- `pnpm test` *(fails: sh: 1: turbo: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b99bac4fd4832b80a6ee1c2dbad6d6