### PR TITLE
feat(frontend): add DecisionCard component and tests

### DIFF
--- a/apps/frontend/src/components/__tests__/decision-card.test.tsx
+++ b/apps/frontend/src/components/__tests__/decision-card.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-// Note: DecisionCard component not yet created locally, skipping for now
-// import { DecisionCard } from '@/components/ui/decision-card'
+import { DecisionCard } from '@/components/ui/decision-card'
 
 const mockProposal = {
   actionId: 'action-001',
@@ -31,17 +30,15 @@ const mockProposal = {
   expiresAt: new Date(Date.now() + 1000 * 60 * 60 * 48) // 48 hours from now
 }
 
-// TODO: Uncomment when DecisionCard component is available locally
-/*
 describe('DecisionCard', () => {
   it('displays proposal information correctly', () => {
     render(<DecisionCard {...mockProposal} />)
-    
+
     expect(screen.getByText('LinkedIn Holiday Post')).toBeInTheDocument()
     expect(screen.getByText('Engaging holiday content for professional audience')).toBeInTheDocument()
     expect(screen.getByText('89%')).toBeInTheDocument() // Readiness score
     expect(screen.getByText('95%')).toBeInTheDocument() // Policy pass
-    expect(screen.getByText('$150')).toBeInTheDocument() // Total cost
+    expect(screen.getByText('$150.00')).toBeInTheDocument() // Total cost
   })
   
   it('displays risk indicators correctly', () => {
@@ -54,8 +51,8 @@ describe('DecisionCard', () => {
   it('shows time until expiry', () => {
     render(<DecisionCard {...mockProposal} />)
     
-    // Should show hours remaining (48h left)
-    expect(screen.getByText(/48h left/)).toBeInTheDocument()
+    // Should show days remaining (2d left)
+    expect(screen.getByText(/2d left/)).toBeInTheDocument()
   })
   
   it('handles expired proposals', () => {
@@ -78,13 +75,13 @@ describe('DecisionCard', () => {
     
     // Click to expand
     await user.click(screen.getByText('More details'))
-    
+
     // Should show cost breakdown
     expect(screen.getByText('Cost Breakdown')).toBeInTheDocument()
     expect(screen.getByText('Paid Ads')).toBeInTheDocument()
-    expect(screen.getByText('$100')).toBeInTheDocument()
+    expect(screen.getByText('$100.00')).toBeInTheDocument()
     expect(screen.getByText('LLM Model Spend')).toBeInTheDocument()
-    expect(screen.getByText('$25')).toBeInTheDocument()
+    expect(screen.getByText('$25.00')).toBeInTheDocument()
   })
   
   it('shows provenance sources when expanded', async () => {
@@ -94,10 +91,10 @@ describe('DecisionCard', () => {
     
     // Expand details first
     await user.click(screen.getByText('More details'))
-    
+
     // Then show sources
-    await user.click(screen.getByText('Show Sources'))
-    
+    await user.click(screen.getByRole('button', { name: /show sources/i }))
+
     expect(screen.getByText('Industry Report 2024')).toBeInTheDocument()
   })
   
@@ -108,29 +105,31 @@ describe('DecisionCard', () => {
     const onRequestChanges = jest.fn()
     
     render(
-      <DecisionCard 
-        {...mockProposal} 
+      <DecisionCard
+        {...mockProposal}
         onApprove={onApprove}
         onReject={onReject}
         onRequestChanges={onRequestChanges}
       />
     )
-    
+
     // Should have action buttons
     expect(screen.getByText('Approve')).toBeInTheDocument()
     expect(screen.getByText('Reject')).toBeInTheDocument()
     expect(screen.getByText('Request Changes')).toBeInTheDocument()
-    
+
     // Test approve action
     await user.click(screen.getByText('Approve'))
     expect(onApprove).toHaveBeenCalledTimes(1)
-    
+
     // Test reject action
     await user.click(screen.getByText('Reject'))
     expect(onReject).toHaveBeenCalledTimes(1)
-    
+
     // Test request changes action
     await user.click(screen.getByText('Request Changes'))
+    await user.type(screen.getByPlaceholderText('Describe the changes needed...'), 'Needs revision')
+    await user.click(screen.getByText('Submit Feedback'))
     expect(onRequestChanges).toHaveBeenCalledTimes(1)
   })
   
@@ -153,7 +152,7 @@ describe('DecisionCard', () => {
   
   it('shows loading state when processing', () => {
     render(<DecisionCard {...mockProposal} loading />)
-    
+
     // Action buttons should be disabled during loading
     expect(screen.getByText('Approve')).toBeDisabled()
     expect(screen.getByText('Reject')).toBeDisabled()
@@ -173,12 +172,11 @@ describe('DecisionCard', () => {
     render(<DecisionCard {...mockProposal} />)
     
     // Card should have proper role
-    const card = screen.getByRole('article') || screen.getByRole('region')
+    const card = screen.getByRole('region', { name: /LinkedIn Holiday Post/i })
     expect(card).toBeInTheDocument()
-    
+
     // Buttons should be properly labeled
     expect(screen.getByRole('button', { name: /approve/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /reject/i })).toBeInTheDocument()
   })
 })
-*/

--- a/apps/frontend/src/components/ui/decision-card.tsx
+++ b/apps/frontend/src/components/ui/decision-card.tsx
@@ -125,7 +125,12 @@ const DecisionCard: React.FC<DecisionCardProps> = ({
   }
 
   return (
-    <Card className={cn("decision-card relative", isExpired && "opacity-75", className)}>
+    <Card
+      role="region"
+      aria-labelledby={`${actionId}-title`}
+      data-testid="decision-card"
+      className={cn("decision-card relative", isExpired && "opacity-75", className)}
+    >
       {isExpired && (
         <div className="absolute top-2 right-2 z-10">
           <Badge variant="destructive">Expired</Badge>
@@ -135,11 +140,16 @@ const DecisionCard: React.FC<DecisionCardProps> = ({
       <CardHeader className="pb-3">
         <div className="flex justify-between items-start">
           <div className="flex-1 pr-4">
-            <CardTitle className="text-lg font-semibold">{title}</CardTitle>
+            <CardTitle
+              id={`${actionId}-title`}
+              className="text-lg font-semibold"
+            >
+              {title}
+            </CardTitle>
             <CardDescription className="mt-1">{oneLine}</CardDescription>
           </div>
           <div className="flex flex-col items-end space-y-1">
-            <Badge 
+            <Badge
               className={cn("text-xs", getRiskColor(duplicateRisk))}
               variant="outline"
             >


### PR DESCRIPTION
## Summary
- add accessible DecisionCard component with test id
- add unit tests covering rendering, actions, and accessibility

## Testing
- `npm test` *(fails: Configuring Next.js via 'next.config.ts' is not supported)*

------
https://chatgpt.com/codex/tasks/task_e_68b99ba4288c832b87ebf97583e4d943
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add an accessible DecisionCard and update tests to cover rendering, actions, and expand/collapse. Improves screen reader support and stabilizes the decision workflow.

- **New Features**
  - Added role="region" with aria-labelledby and data-testid on the card; title now has a labeled id.
  - Updated tests to use accessible queries and cover approve/reject/request changes (with feedback), provenance sources, loading, and expired states.
  - Aligned expectations to current UI (currency with two decimals, time-left shown in days).

<!-- End of auto-generated description by cubic. -->

