### PR TITLE
Add proprietary license and update README references

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,8 @@
+SMM Architect Proprietary License
+
+Copyright (c) 2024 SMM Architect Team
+
+All rights reserved. This software and its source code are proprietary and confidential. Unauthorized copying, modification, distribution, or use in any form is strictly prohibited without prior written permission from the copyright holders.
+
+The software is provided "as is", without warranty of any kind, express or implied, including but not limited to the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the authors or copyright holders be liable for any claim, damages, or other liability, whether in an action of contract, tort, or otherwise, arising from, out of, or in connection with the software or the use or other dealings in the software.
+

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SMM Architect
 
 [![CI Status](https://github.com/yourorg/smm-architect/workflows/CI/badge.svg)](https://github.com/yourorg/smm-architect/actions)
-[![License](https://img.shields.io/badge/license-Proprietary-red.svg)](LICENSE)
+[![License](https://img.shields.io/badge/license-Proprietary-red.svg)](./LICENSE)
 [![Version](https://img.shields.io/badge/version-1.0.0-blue.svg)](CHANGELOG.md)
 [![Status](https://img.shields.io/badge/status-Production%20Ready-brightgreen.svg)](AGENTS.md)
 
@@ -453,7 +453,7 @@ See `examples/workspace-contract.icblabs.json` for a complete example workspace 
 
 ## 📄 License
 
-This project is proprietary software. See [LICENSE](LICENSE) for details.
+This project is proprietary software. See [LICENSE](./LICENSE) for details.
 
 ## 🙋‍♀️ Support
 


### PR DESCRIPTION
## Summary
- add proprietary license file
- link README badges and license section to new license file

## Testing
- `make test` *(fails: tsup command not found)*
- `make test-security` *(fails: RLS violations in migrations)*

------
https://chatgpt.com/codex/tasks/task_e_68b99b920594832b8494723bec1befe2
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds the SMM Architect Proprietary License and updates README links to point to it. Ensures the license badge and License section correctly reference ./LICENSE.

<!-- End of auto-generated description by cubic. -->

