### PR TITLE
docs: add production readiness guide

### DIFF
--- a/PRODUCTION-READY.md
+++ b/PRODUCTION-READY.md
@@ -1,0 +1,104 @@
+# SMM Architect Production Readiness
+
+This guide outlines the steps required to deploy SMM Architect to a production environment and verify the platform is ready to serve live traffic.
+
+## Prerequisites
+
+- Node.js 18+
+- Docker 20+ and Docker Compose
+- Kubernetes 1.24+ with `kubectl` and Helm 3.8+
+- HashiCorp Vault for secrets management
+- PostgreSQL 14+ (managed or self-hosted)
+- Open Policy Agent (OPA) CLI for policy testing
+- Global CLIs: `@encore/cli`
+
+## Environment Configuration
+
+Create a `.env` file or export the following variables before deployment:
+
+```bash
+# Core
+NODE_ENV=production
+PORT=4000
+LOG_LEVEL=info
+
+# Database & Cache
+DATABASE_URL=postgresql://user:pass@db-host:5432/smm_architect
+REDIS_URL=redis://redis-host:6379
+
+# Secrets
+VAULT_URL=https://vault.example.com
+VAULT_TOKEN=<vault-token>
+JWT_SECRET=<32+ chars>
+ENCRYPTION_KEY=<32+ chars>
+
+# External Services
+OPENAI_API_KEY=<openai-key>
+ANTHROPIC_API_KEY=<anthropic-key>
+PINECONE_API_KEY=<pinecone-key>
+N8N_URL=https://n8n.example.com
+AGENTUITY_URL=https://agentuity.example.com
+
+# Monitoring
+SENTRY_DSN=<sentry-dsn>
+PROMETHEUS_ENABLED=true
+```
+
+## Deployment Steps
+
+1. **Install dependencies**
+   ```bash
+   npm install -g @encore/cli
+   ```
+
+2. **Start services** using the production compose file:
+   ```bash
+   docker compose -f docker-compose.prod.yml up -d
+   ```
+   Services exposed:
+   - SMM Architect API: `http://localhost:4000`
+   - ToolHub Service: `http://localhost:3001`
+   - Frontend: `http://localhost:3000`
+   - Prometheus: `http://localhost:9090`
+   - Grafana: `http://localhost:3001`
+
+3. **Run database migrations** (handled by Encore in the core service):
+   ```bash
+   cd services/smm-architect
+   encore db setup
+   encore db migrate
+   ```
+
+## Final Validation
+
+Run the full test and security suite:
+```bash
+make test && make test-security
+```
+
+Execute the production readiness check script to verify infrastructure, configuration, and monitoring:
+```bash
+./tools/scripts/production-readiness-check.sh
+```
+
+(Optional) Run disaster recovery tests:
+```bash
+./tools/scripts/disaster-recovery.sh --test-only
+```
+
+## Monitoring & Alerting
+
+- Metrics endpoints:
+  - SMM Architect: `http://localhost:4000/metrics`
+  - ToolHub: `http://localhost:3001/metrics`
+- Dashboards and alerting configuration: see [`monitoring/README.md`](monitoring/README.md).
+
+## Rollback & Recovery
+
+- Disaster recovery automation: [`tools/scripts/disaster-recovery.sh`](tools/scripts/disaster-recovery.sh)
+- Operational runbooks and rollback procedures: [`docs/operational-runbooks.md`](docs/operational-runbooks.md)
+
+## Additional Resources
+
+- Deployment details: [`docs/deployment.md`](docs/deployment.md)
+- Comprehensive QA & validation: [`docs/production-readiness-guide.md`](docs/production-readiness-guide.md)


### PR DESCRIPTION
## Summary
- add PRODUCTION-READY.md outlining deployment prerequisites and environment setup
- document service startup, validation scripts, and monitoring links
- reference disaster recovery runbooks for rollback procedures

## Testing
- `make test` *(fails: turbo: not found)*
- `make test-security` *(fails: Makefile:44: test-security Error 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b99b8fb2fc832b861fa9dd0164ecea
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds PRODUCTION-READY.md with a step-by-step guide to deploy SMM Architect to production and verify it can serve live traffic. Covers prerequisites, environment variables, Docker/Kubernetes setup, Encore DB migrations, readiness and DR scripts, monitoring endpoints, and rollback/runbook links.

<!-- End of auto-generated description by cubic. -->

