### PR TITLE
feat: implement S3 archival for TTL job

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1057,6 +1057,9 @@ importers:
 
   services/smm-architect:
     dependencies:
+      '@aws-sdk/client-s3':
+        specifier: ^3.445.0
+        version: 3.876.0
       '@google-cloud/kms':
         specifier: ^4.0.0
         version: 4.5.0

--- a/services/smm-architect/package.json
+++ b/services/smm-architect/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "encore.dev": "^1.0.0",
+    "@aws-sdk/client-s3": "^3.445.0",
     "@google-cloud/kms": "^4.0.0",
     "node-vault": "^0.10.0",
     "ajv": "^8.12.0",


### PR DESCRIPTION
## Summary
- implement gzip-compressed S3 uploads for TTL archival job
- add AWS credentials and bucket configuration with logging
- include @aws-sdk/client-s3 dependency

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b99b93b838832badc81a5addff00d9
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds gzip-compressed S3 archival to the TTL job so expired workspace data is uploaded to S3 with clear logging and error handling. Configurable via env for bucket, region, and optional AWS credentials.

- New Features
  - Uploads archived workspace JSON to S3 as gzip via PutObject.
  - Generates keys: archived-workspaces/{workspace_id}/{timestamp}.json.gz and returns the s3:// URI.
  - Adds TTLArchivalConfig fields and env defaults: ARCHIVE_S3_BUCKET, AWS_REGION, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY.
  - Logs start/success/failure with payload size.

- Dependencies
  - Added @aws-sdk/client-s3 (^3.445.0).

<!-- End of auto-generated description by cubic. -->

