### PR TITLE
ci: enforce lint and type check

### DIFF
--- a/.github/workflows/ci-cd-secure.yml
+++ b/.github/workflows/ci-cd-secure.yml
@@ -65,6 +65,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Run linting
+        run: pnpm lint
+
+      - name: Run type check
+        run: pnpm type-check
+
       - name: Build application
         run: pnpm build
 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -35,12 +35,15 @@ jobs:
     
     - name: Install dependencies
       run: pnpm install
-    
+
     - name: Run linting
-      run: pnpm run lint
-    
+      run: pnpm lint
+
+    - name: Run type check
+      run: pnpm type-check
+
     - name: Run tests
-      run: pnpm run test
+      run: pnpm test
       env:
         NODE_ENV: test
     

--- a/.github/workflows/security-ci.yml
+++ b/.github/workflows/security-ci.yml
@@ -123,8 +123,14 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Run linting
+        run: pnpm lint
+
+      - name: Run type check
+        run: pnpm type-check
+
       - name: Build project
-        run: pnpm run build
+        run: pnpm build
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@afb54ba388a7dca6ecae48f608c4ff05ff4cc77a # v3.25.15

--- a/README.md
+++ b/README.md
@@ -450,6 +450,7 @@ See `examples/workspace-contract.icblabs.json` for a complete example workspace 
 - Update documentation for new features
 - Validate against schema and policy rules
 - Test policy changes thoroughly
+- Ensure `pnpm lint` and `pnpm type-check` pass before building
 
 ## 📄 License
 

--- a/apps/frontend/README.md
+++ b/apps/frontend/README.md
@@ -20,6 +20,18 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+## Build requirements
+
+Before building the application, ensure code quality checks pass:
+
+```bash
+pnpm lint
+pnpm type-check
+pnpm build
+```
+
+The build will fail if ESLint or TypeScript errors are detected.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/apps/frontend/next.config.ts
+++ b/apps/frontend/next.config.ts
@@ -92,19 +92,7 @@ const nextConfig: NextConfig = {
   
   // SWC minification
   swcMinify: true,
-  
-  // Temporarily disable strict linting to get build working
-  eslint: {
-    // Warning: This allows production builds to successfully complete even if
-    // your project has ESLint errors.
-    ignoreDuringBuilds: true,
-  },
-  typescript: {
-    // Warning: This allows production builds to successfully complete even if
-    // your project has TypeScript errors.
-    ignoreBuildErrors: true,
-  },
-  
+
   // Environment variables
   env: {
     NEXT_PUBLIC_APP_VERSION: process.env.npm_package_version || '1.0.0',


### PR DESCRIPTION
## Summary
- enforce lint and type checks in Next.js build
- run `pnpm lint` and `pnpm type-check` in CI workflows
- document new build requirements for developers

## Testing
- `pnpm --filter @smm-architect/frontend lint` *(fails: next not found)*
- `pnpm --filter @smm-architect/frontend type-check` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b991428248832b9b8e546d57e1be5a
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Enforces ESLint and TypeScript checks in CI and Next.js builds. Builds now fail on lint or type errors, with CI running pnpm lint and pnpm type-check before build and tests.

- **Refactors**
  - CI: added lint and type-check steps to ci-cd, ci-cd-secure, and security-ci; standardized commands (pnpm lint/test/build).
  - Next.js: removed ignoreDuringBuilds and ignoreBuildErrors in apps/frontend/next.config.ts.
  - Docs: updated root and frontend READMEs with build requirements.

- **Migration**
  - Run pnpm lint and pnpm type-check locally and fix issues before pnpm build.
  - CI will block merges if ESLint or TypeScript errors are present.

<!-- End of auto-generated description by cubic. -->

