### PR TITLE
Add prerequisite checks to security test runner

### DIFF
--- a/tools/assessment/README.md
+++ b/tools/assessment/README.md
@@ -268,6 +268,8 @@ npm run assess  # (includes agent validation)
 
 These scripts remain complementary to the assessment system:
 - `run-security-tests.sh` - Specific security testing
+  - Prerequisites: `pnpm`, `jq`, `jest`
+  - Usage: `./tools/scripts/run-security-tests.sh`
 - `generate-sbom.sh` - SBOM generation
 - `deploy-*.sh` - Deployment automation
 - `setup-*.sh` - Environment setup

--- a/tools/scripts/run-security-tests.sh
+++ b/tools/scripts/run-security-tests.sh
@@ -3,6 +3,15 @@ set -euo pipefail
 
 # Comprehensive Security Test Runner for SMM Architect
 # Runs all security tests and generates compliance reports
+#
+# Usage: ./tools/scripts/run-security-tests.sh
+#
+# Prerequisites:
+#   - pnpm
+#   - jq
+#   - Jest (installed via pnpm)
+#
+# Ensure project dependencies are installed with `pnpm install` before running.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
@@ -30,6 +39,34 @@ log_warning() {
 
 log_error() {
     echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Check if a command exists
+command_exists() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+# Verify required tools are installed
+check_prerequisites() {
+    local missing=false
+
+    for cmd in pnpm npm jq; do
+        if ! command_exists "$cmd"; then
+            log_error "Required tool '$cmd' is not installed. Please install it before running this script."
+            missing=true
+        fi
+    done
+
+    if command_exists pnpm && ! pnpm exec jest --version >/dev/null 2>&1; then
+        log_error "Jest test framework is not installed. Run 'pnpm install' to install project dependencies."
+        missing=true
+    fi
+
+    if [ "$missing" = true ]; then
+        exit 1
+    fi
+
+    log_success "All prerequisite tools available"
 }
 
 # Create reports directory
@@ -322,7 +359,8 @@ EOF
 main() {
     log_info "🚨 Starting comprehensive security test suite..."
     log_info "Report directory: ${REPORTS_DIR}"
-    
+
+    check_prerequisites
     setup_reports_directory
     
     # Run all security tests


### PR DESCRIPTION
## Summary
- ensure `run-security-tests.sh` verifies required tools like pnpm, jq, and Jest
- document prerequisites and usage for security test runner in both script and assessment README

## Testing
- `bash -n tools/scripts/run-security-tests.sh`
- `./tools/scripts/run-security-tests.sh` *(fails: Jest test framework is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b99140f420832bbbce967f883234db
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds prerequisite checks to run-security-tests.sh to verify pnpm, jq, and Jest before running, preventing confusing failures. Also documents prerequisites and usage in the assessment README and script header.

- **New Features**
  - Validate pnpm, jq, and Jest availability; fail fast with clear errors.
  - Added a success message when all tools are available before running tests.

<!-- End of auto-generated description by cubic. -->

