### PR TITLE
Ensure pooled DB clients clean up connections

### DIFF
--- a/tests/tools/assessment/database.test.js
+++ b/tests/tools/assessment/database.test.js
@@ -1,0 +1,55 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import ts from 'typescript';
+import fs from 'node:fs';
+import vm from 'node:vm';
+import path from 'node:path';
+
+function loadModule() {
+  const source = fs.readFileSync(path.resolve('tools/assessment/utils/database.ts'), 'utf8');
+  const transpiled = ts.transpileModule(source, { compilerOptions: { module: ts.ModuleKind.CommonJS } });
+
+  const releaseMock = function () { releaseMock.calls++; };
+  releaseMock.calls = 0;
+  const endMock = async function () { endMock.calls++; };
+  endMock.calls = 0;
+
+ const sandbox = {
+   require: (mod) => {
+      if (mod === 'pg') {
+        return {
+          Pool: class {
+            async connect() { return { release: releaseMock }; }
+            async end() { await endMock(); }
+          }
+        };
+      }
+      throw new Error(`Unexpected module ${mod}`);
+    },
+  };
+  sandbox.exports = {};
+  sandbox.module = { exports: sandbox.exports };
+  sandbox.process = { env: {} };
+
+  vm.runInNewContext(transpiled.outputText, sandbox, { filename: 'database.js' });
+  return { ...sandbox.module.exports, releaseMock, endMock };
+}
+
+const { withTestDatabaseClient, releaseMock, endMock } = loadModule();
+
+test('releases connection after successful callback', async () => {
+  await withTestDatabaseClient({}, async () => {});
+  assert.equal(releaseMock.calls, 1);
+  assert.equal(endMock.calls, 1);
+});
+
+test('releases connection even if callback throws', async () => {
+  await assert.rejects(
+    withTestDatabaseClient({}, async () => {
+      throw new Error('failure');
+    }),
+    /failure/
+  );
+  assert.equal(releaseMock.calls, 2);
+  assert.equal(endMock.calls, 2);
+});

--- a/tools/assessment/@types/pg.d.ts
+++ b/tools/assessment/@types/pg.d.ts
@@ -1,0 +1,11 @@
+declare module 'pg' {
+  export class Pool {
+    constructor(config: any);
+    connect(): Promise<PoolClient>;
+    end(): Promise<void>;
+  }
+  export interface PoolClient {
+    query: (...args: any[]) => any;
+    release: () => void;
+  }
+}


### PR DESCRIPTION
## Summary
- use `pg.Pool` for assessment DB utilities
- add helper to auto-cleanup connections
- test that connections are released even when callbacks throw

## Testing
- `node --test tests/tools/assessment/database.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b9913e3a00832b9c4e58500f8dde73
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Switched assessment DB utilities to a pooled PostgreSQL client and added automatic cleanup to prevent leaked connections, even when callbacks throw. Added tests to verify connections are always released.

- **Refactors**
  - Replaced pg.Client with pg.Pool and added local pg type declarations; closeDatabaseClient now calls client.release and pool.end.
  - Introduced withTestDatabaseClient to scope client lifetime and always clean up after the callback.

- **Bug Fixes**
  - Ensures connections are released on both success and error paths; tests assert release/end in both cases.

<!-- End of auto-generated description by cubic. -->

