### PR TITLE
Parameterize Postgres credentials and secure production secrets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,12 @@ SENTRY_ENABLED=true
 NODE_ENV=development
 PORT=3000
 
+# Database Configuration
+POSTGRES_DB=smm_architect
+POSTGRES_USER=example_user
+POSTGRES_PASSWORD=example_password
+POSTGRES_MULTIPLE_DATABASES=smm_architect,smm_test
+
 # Optional: Sentry Release Tracking
 npm_package_version=1.0.0
 APP_VERSION=1.0.0

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -12,12 +12,17 @@ services:
     environment:
       - NODE_ENV=production
       - PORT=4000
-      - DATABASE_URL=${DATABASE_URL}
-      - REDIS_URL=${REDIS_URL}
+      - DATABASE_URL_FILE=/run/secrets/database_url
+      - REDIS_URL_FILE=/run/secrets/redis_url
       - VAULT_URL=${VAULT_URL}
-      - VAULT_TOKEN=${VAULT_TOKEN}
-      - SENTRY_DSN=${SENTRY_DSN}
+      - VAULT_TOKEN_FILE=/run/secrets/vault_token
+      - SENTRY_DSN_FILE=/run/secrets/sentry_dsn
       - SENTRY_ENVIRONMENT=production
+    secrets:
+      - database_url
+      - redis_url
+      - vault_token
+      - sentry_dsn
     volumes:
       - smm_logs:/app/logs
     networks:
@@ -51,18 +56,24 @@ services:
     environment:
       - NODE_ENV=production
       - PORT=3001
-      - DATABASE_URL=${DATABASE_URL}
-      - REDIS_URL=${REDIS_URL}
+      - DATABASE_URL_FILE=/run/secrets/database_url
+      - REDIS_URL_FILE=/run/secrets/redis_url
       - VAULT_URL=${VAULT_URL}
-      - VAULT_TOKEN=${VAULT_TOKEN}
-      - SENTRY_DSN=${SENTRY_DSN}
+      - VAULT_TOKEN_FILE=/run/secrets/vault_token
+      - SENTRY_DSN_FILE=/run/secrets/sentry_dsn
       - SENTRY_ENVIRONMENT=production
-      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - OPENAI_API_KEY_FILE=/run/secrets/openai_api_key
     volumes:
       - toolhub_logs:/app/logs
     networks:
       - smm-network
     restart: unless-stopped
+    secrets:
+      - database_url
+      - redis_url
+      - vault_token
+      - sentry_dsn
+      - openai_api_key
     deploy:
       replicas: 2
       update_config:
@@ -91,11 +102,13 @@ services:
       - NODE_ENV=production
       - NEXT_PUBLIC_API_URL=${API_URL}
       - NEXT_PUBLIC_TOOLHUB_URL=${TOOLHUB_URL}
-      - SENTRY_DSN=${SENTRY_DSN}
+      - SENTRY_DSN_FILE=/run/secrets/sentry_dsn
       - SENTRY_ENVIRONMENT=production
     networks:
       - smm-network
     restart: unless-stopped
+    secrets:
+      - sentry_dsn
     deploy:
       replicas: 2
       update_config:
@@ -154,8 +167,8 @@ services:
     ports:
       - "3001:3000"
     environment:
-      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD}
-      - GF_SECURITY_SECRET_KEY=${GRAFANA_SECRET_KEY}
+      - GF_SECURITY_ADMIN_PASSWORD_FILE=/run/secrets/grafana_password
+      - GF_SECURITY_SECRET_KEY_FILE=/run/secrets/grafana_secret_key
       - GF_USERS_ALLOW_SIGN_UP=false
     volumes:
       - grafana_data:/var/lib/grafana
@@ -163,6 +176,9 @@ services:
     networks:
       - smm-network
     restart: unless-stopped
+    secrets:
+      - grafana_password
+      - grafana_secret_key
 
 # Volumes
 volumes:
@@ -183,3 +199,19 @@ networks:
     ipam:
       config:
         - subnet: 172.20.0.0/16
+
+secrets:
+  database_url:
+    external: true
+  redis_url:
+    external: true
+  vault_token:
+    external: true
+  sentry_dsn:
+    external: true
+  openai_api_key:
+    external: true
+  grafana_password:
+    external: true
+  grafana_secret_key:
+    external: true

--- a/docker-compose.secure.yml
+++ b/docker-compose.secure.yml
@@ -7,8 +7,8 @@ services:
     container_name: smm-postgres
     restart: unless-stopped
     environment:
-      POSTGRES_DB: smm_architect
-      POSTGRES_USER: smm_user
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD_FILE: /run/secrets/postgres_password
     secrets:
       - postgres_password
@@ -20,7 +20,7 @@ services:
     networks:
       - smm-network
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U smm_user -d smm_architect"]
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,17 +6,17 @@ services:
     image: postgres:14-alpine
     container_name: smm-postgres
     environment:
-      POSTGRES_DB: smm_architect
-      POSTGRES_USER: smm_user
-      POSTGRES_PASSWORD: smm_password
-      POSTGRES_MULTIPLE_DATABASES: smm_architect,smm_test
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_MULTIPLE_DATABASES: ${POSTGRES_MULTIPLE_DATABASES}
     ports:
       - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./services/smm-architect/migrations:/docker-entrypoint-initdb.d
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U smm_user -d smm_architect"]
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -49,7 +49,7 @@ services:
     environment:
       - NODE_ENV=development
       - PORT=4000
-      - DATABASE_URL=postgresql://smm_user:smm_password@postgres:5432/smm_architect
+      - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
       - REDIS_URL=redis://redis:6379
       - VAULT_URL=http://vault:8200
       - SENTRY_DSN=${SENTRY_DSN}
@@ -75,7 +75,7 @@ services:
     environment:
       - NODE_ENV=development
       - PORT=3001
-      - DATABASE_URL=postgresql://smm_user:smm_password@postgres:5432/smm_architect
+      - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
       - REDIS_URL=redis://redis:6379
       - VAULT_URL=http://vault:8200
       - SENTRY_DSN=${SENTRY_DSN}


### PR DESCRIPTION
## Summary
- reference Postgres credentials via environment variables in docker-compose
- document required Postgres environment variables
- use secret files for database and other sensitive values in production compose files

## Testing
- `make test` *(fails: turbo not found)*
- `make test-security` *(fails: multiple RLS violations)*

------
https://chatgpt.com/codex/tasks/task_e_68b99f68f3cc832b8d51563032724132