### PR TITLE
feat: add log rotation to shared logger

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,11 @@ SENTRY_ENABLED=true
 # Application Configuration
 NODE_ENV=development
 PORT=3000
+LOG_LEVEL=info
+LOG_DIRECTORY=logs
+LOG_ROTATION_SIZE=10M
+LOG_ROTATION_INTERVAL=1d
+LOG_ROTATION_MAX_FILES=14
 
 # Optional: Sentry Release Tracking
 npm_package_version=1.0.0

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -110,6 +110,20 @@ N8N_BASIC_AUTH_USER=admin
 N8N_BASIC_AUTH_PASSWORD=admin
 ```
 
+### Log Management
+
+Application logs are written to rotating files and retained for analysis or shipping to a centralized log service.
+
+```
+# Log directory and rotation settings
+LOG_DIRECTORY=./logs
+LOG_ROTATION_SIZE=10M       # rotate when file exceeds 10MB
+LOG_ROTATION_INTERVAL=1d    # rotate daily
+LOG_ROTATION_MAX_FILES=14   # keep 14 archived logs
+```
+
+By default logs are stored under `./logs`. Tools like Fluentd can tail this directory to forward logs to Elasticsearch or any other central service.
+
 ## Kubernetes Deployment
 
 ### Prerequisites Setup

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -21,6 +21,7 @@
     "@sentry/profiling-node": "^7.99.0",
     "ajv": "^8.12.0",
     "date-fns": "^2.30.0",
+    "rotating-file-stream": "^3.2.7",
     "uuid": "^9.0.0",
     "winston": "^3.11.0",
     "zod": "^3.22.4"

--- a/packages/shared/src/utils/logger.ts
+++ b/packages/shared/src/utils/logger.ts
@@ -3,8 +3,23 @@
  */
 
 import winston from 'winston';
+import { createStream } from 'rotating-file-stream';
+import fs from 'node:fs';
+import path from 'node:path';
 
 const logLevel = process.env['LOG_LEVEL'] || 'info';
+const logDirectory = process.env['LOG_DIRECTORY'] || path.join(process.cwd(), 'logs');
+
+if (!fs.existsSync(logDirectory)) {
+  fs.mkdirSync(logDirectory, { recursive: true });
+}
+
+const rotatingStream = createStream('app.log', {
+  size: process.env['LOG_ROTATION_SIZE'] || '10M',
+  interval: process.env['LOG_ROTATION_INTERVAL'] || '1d',
+  maxFiles: parseInt(process.env['LOG_ROTATION_MAX_FILES'] || '14', 10),
+  path: logDirectory
+});
 
 export const logger = winston.createLogger({
   level: logLevel,
@@ -20,7 +35,8 @@ export const logger = winston.createLogger({
         winston.format.colorize(),
         winston.format.simple()
       )
-    })
+    }),
+    new winston.transports.Stream({ stream: rotatingStream })
   ]
 });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -305,6 +305,9 @@ importers:
       date-fns:
         specifier: ^2.30.0
         version: 2.30.0
+      rotating-file-stream:
+        specifier: ^3.2.7
+        version: 3.2.7
       uuid:
         specifier: ^9.0.0
         version: 9.0.1
@@ -22550,6 +22553,11 @@ packages:
       '@rollup/rollup-win32-x64-msvc': 4.49.0
       fsevents: 2.3.3
     dev: true
+
+  /rotating-file-stream@3.2.7:
+    resolution: {integrity: sha512-SVquhBEVvRFY+nWLUc791Y0MIlyZrEClRZwZFLLRgJKldHyV1z4e2e/dp9LPqCS3AM//uq/c3PnOFgjqnm5P+A==}
+    engines: {node: '>=14.0'}
+    dev: false
 
   /router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}

--- a/tests/unit/logger-rotation.test.ts
+++ b/tests/unit/logger-rotation.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, beforeAll, afterAll, jest } from '@jest/globals';
+import { mkdtempSync, readdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+describe('logger file rotation', () => {
+  let tempDir: string;
+
+  beforeAll(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'logs-'));
+    process.env.LOG_DIRECTORY = tempDir;
+  });
+
+  afterAll(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+    delete process.env.LOG_DIRECTORY;
+  });
+
+  it('writes logs to a rotating file', async () => {
+    jest.isolateModules(() => {
+      const { logger } = require('../../packages/shared/src/utils/logger');
+      logger.info('rotation test');
+      logger.close();
+    });
+    await new Promise(resolve => setTimeout(resolve, 200));
+    const files = readdirSync(tempDir);
+    expect(files.some(f => f.endsWith('.log'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add rotating-file-stream transport for persistent log rotation
- expose log rotation env vars and document deployment steps
- test rotating logger writes to files

## Testing
- `npx jest tests/unit/logger-rotation.test.ts`
- `pre-commit run --files packages/shared/src/utils/logger.ts packages/shared/package.json pnpm-lock.yaml .env.example docs/deployment.md tests/unit/logger-rotation.test.ts` *(fails: Type tag 'typescript' is not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_68b99136fef0832badf1dccfe649680e
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add file rotation to the shared logger so logs persist to disk and rotate by size and time. This makes logs easier to retain and ship to a central service.

- **New Features**
  - Rotate logs via rotating-file-stream; auto-create log directory; default retention keeps 14 files.
  - New env vars: LOG_LEVEL, LOG_DIRECTORY, LOG_ROTATION_SIZE, LOG_ROTATION_INTERVAL, LOG_ROTATION_MAX_FILES; documented in docs/deployment.md and .env.example.
  - Unit test verifies logs are written to a rotating file.

- **Dependencies**
  - Added rotating-file-stream.

<!-- End of auto-generated description by cubic. -->

