### PR TITLE
feat: add winston logging to smm service

### DIFF
--- a/services/smm-architect/package.json
+++ b/services/smm-architect/package.json
@@ -30,7 +30,9 @@
     "uuid": "^9.0.0",
     "date-fns": "^2.30.0",
     "@sentry/node": "^7.99.0",
-    "@sentry/profiling-node": "^7.99.0"
+    "@sentry/profiling-node": "^7.99.0",
+    "cors": "^2.8.5",
+    "express": "^5.1.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/services/smm-architect/src/config/logger.ts
+++ b/services/smm-architect/src/config/logger.ts
@@ -1,0 +1,23 @@
+import { createLogger, format, transports } from 'winston';
+import path from 'path';
+
+const level = process.env.LOG_LEVEL || 'info';
+
+const logger = createLogger({
+  level,
+  format: format.combine(
+    format.timestamp(),
+    format.errors({ stack: true }),
+    format.printf(({ timestamp, level, message, ...meta }) => {
+      const metaString = Object.keys(meta).length ? ` ${JSON.stringify(meta)}` : '';
+      return `${timestamp} [${level}] ${message}${metaString}`;
+    })
+  ),
+  transports: [
+    new transports.Console(),
+    new transports.File({ filename: path.join('logs', 'error.log'), level: 'error' }),
+    new transports.File({ filename: path.join('logs', 'combined.log') })
+  ]
+});
+
+export default logger;

--- a/services/smm-architect/src/config/sentry.ts
+++ b/services/smm-architect/src/config/sentry.ts
@@ -1,16 +1,10 @@
+import logger from './logger';
+
 // Mock sentry-utils implementation
 function initializeSentry(config: any, context: any) {
   // Mock initialization
-  console.log('Sentry initialized (mock)', config, context);
+  logger.info('Sentry initialized (mock)', { config, context });
 }
-
-// Mock log implementation
-const log = {
-  info: (message: string, data?: any) => console.log('[INFO]', message, data),
-  error: (message: string, data?: any) => console.error('[ERROR]', message, data),
-  debug: (message: string, data?: any) => console.log('[DEBUG]', message, data),
-  warn: (message: string, data?: any) => console.warn('[WARN]', message, data)
-};
 
 // Sentry configuration
 const sentryConfig = {
@@ -35,9 +29,9 @@ const serviceContext = {
 // Initialize Sentry
 try {
   initializeSentry(sentryConfig, serviceContext);
-  log.info("Sentry initialized for smm-architect service");
+  logger.info("Sentry initialized for smm-architect service");
 } catch (error) {
-  log.error("Failed to initialize Sentry", { error: error instanceof Error ? error.message : String(error) });
+  logger.error("Failed to initialize Sentry", { error: error instanceof Error ? error.message : String(error) });
 }
 
 export default sentryConfig;

--- a/services/smm-architect/src/middleware/rate-limit.ts
+++ b/services/smm-architect/src/middleware/rate-limit.ts
@@ -5,13 +5,7 @@
  * on authentication endpoints and other sensitive operations.
  */
 
-// Mock log implementation
-const log = {
-  info: (message: string, data?: any) => console.log('[INFO]', message, data),
-  error: (message: string, data?: any) => console.error('[ERROR]', message, data),
-  debug: (message: string, data?: any) => console.log('[DEBUG]', message, data),
-  warn: (message: string, data?: any) => console.warn('[WARN]', message, data)
-};
+import logger from '../config/logger';
 
 // In-memory store for demo - in production use Redis
 interface RateLimitEntry {
@@ -50,7 +44,7 @@ export async function rateLimit(
     };
     rateLimitStore.set(key, entry);
     
-    log.debug("Rate limit - new window", { 
+    logger.debug("Rate limit - new window", { 
       category, 
       identifier: maskIdentifier(identifier), 
       count: 1, 
@@ -67,7 +61,7 @@ export async function rateLimit(
   if (entry.count > maxAttempts) {
     const timeUntilReset = Math.ceil((entry.resetTime - now) / 1000);
     
-    log.warn("Rate limit exceeded", {
+    logger.warn("Rate limit exceeded", {
       category,
       identifier: maskIdentifier(identifier),
       attempts: entry.count,
@@ -80,7 +74,7 @@ export async function rateLimit(
     );
   }
   
-  log.debug("Rate limit check", {
+  logger.debug("Rate limit check", {
     category,
     identifier: maskIdentifier(identifier),
     count: entry.count,
@@ -133,7 +127,7 @@ export async function clearRateLimit(
   const key = `${category}:${identifier}`;
   rateLimitStore.delete(key);
   
-  log.info("Rate limit cleared", {
+  logger.info("Rate limit cleared", {
     category,
     identifier: maskIdentifier(identifier)
   });
@@ -154,7 +148,7 @@ export function cleanupExpiredEntries(): void {
   }
   
   if (cleaned > 0) {
-    log.debug("Rate limit cleanup", { expiredEntries: cleaned });
+    logger.debug("Rate limit cleanup", { expiredEntries: cleaned });
   }
 }
 

--- a/services/smm-architect/src/services/simulation-service.ts
+++ b/services/smm-architect/src/services/simulation-service.ts
@@ -1,11 +1,5 @@
-// Mock log implementation
-const log = {
-  info: (message: string, data?: any) => console.log('[INFO]', message, data),
-  error: (message: string, data?: any) => console.error('[ERROR]', message, data),
-  debug: (message: string, data?: any) => console.log('[DEBUG]', message, data),
-  warn: (message: string, data?: any) => console.warn('[WARN]', message, data)
-};
 import { v4 as uuidv4 } from "uuid";
+import logger from "../config/logger";
 import { 
   WorkspaceContract, 
   SimulationRequest, 
@@ -19,7 +13,7 @@ export class SimulationService {
     const simulationId = `sim-${uuidv4()}`;
     const startTime = Date.now();
 
-    log.info("Starting simulation", { 
+    logger.info("Starting simulation", { 
       simulationId, 
       workspaceId: workspace.workspaceId,
       iterations: workspace.simulationConfig?.iterations || 1000
@@ -39,7 +33,7 @@ export class SimulationService {
       const decisionCard = await this.createDecisionCard(workspace, monteCarloResults, readinessScore);
 
       const endTime = Date.now();
-      log.info("Simulation completed", { 
+      logger.info("Simulation completed", { 
         simulationId, 
         durationMs: endTime - startTime,
         readinessScore 
@@ -57,7 +51,7 @@ export class SimulationService {
       };
 
     } catch (error) {
-      log.error("Simulation failed", { simulationId, error: error instanceof Error ? error.message : String(error) });
+      logger.error("Simulation failed", { simulationId, error: error instanceof Error ? error.message : String(error) });
       throw error;
     }
   }

--- a/services/smm-architect/src/services/workspace-service.ts
+++ b/services/smm-architect/src/services/workspace-service.ts
@@ -3,19 +3,13 @@ interface SQLDatabase {
   query(sql: string, params?: any[]): Promise<any[]>;
   exec(sql: string, params?: any[]): Promise<void>;
 }
-
-const log = {
-  info: (message: string, data?: any) => console.log('[INFO]', message, data),
-  error: (message: string, data?: any) => console.error('[ERROR]', message, data),
-  debug: (message: string, data?: any) => console.log('[DEBUG]', message, data),
-  warn: (message: string, data?: any) => console.warn('[WARN]', message, data)
-};
 import { v4 as uuidv4 } from "uuid";
-import { 
-  WorkspaceContract, 
+import logger from "../config/logger";
+import {
+  WorkspaceContract,
   CreateWorkspaceRequest,
   ApprovalRequest,
-  ApprovalResponse 
+  ApprovalResponse
 } from "../types";
 
 export class WorkspaceService {
@@ -51,7 +45,7 @@ export class WorkspaceService {
       ]
     );
 
-    log.info("Workspace stored in database", { workspaceId });
+    logger.info("Workspace stored in database", { workspaceId });
 
     return workspace;
   }
@@ -112,7 +106,7 @@ export class WorkspaceService {
       }
     });
 
-    log.info("Workspace decommissioned", { workspaceId });
+    logger.info("Workspace decommissioned", { workspaceId });
     return true;
   }
 

--- a/services/smm-architect/src/utils/validation.ts
+++ b/services/smm-architect/src/utils/validation.ts
@@ -3,6 +3,7 @@ import addFormats from "ajv-formats";
 import fs from "fs";
 import path from "path";
 import { WorkspaceContract } from "../types";
+import logger from "../config/logger";
 
 // Initialize AJV with formats support
 const ajv = new Ajv({ allErrors: true });
@@ -15,7 +16,7 @@ let workspaceSchema: any;
 try {
   workspaceSchema = JSON.parse(fs.readFileSync(schemaPath, "utf8"));
 } catch (error) {
-  console.warn("Could not load workspace schema, using basic validation");
+  logger.warn("Could not load workspace schema, using basic validation");
   workspaceSchema = null;
 }
 


### PR DESCRIPTION
## Summary
- add centralized winston logger with console and file transports
- replace console logging across SMM Architect service modules
- add express and cors dependencies for tests

## Testing
- `npm test`
- `npm run test:security`


------
https://chatgpt.com/codex/tasks/task_e_68b991303b64832b954af8de3d1b3204