### PR TITLE
Add tenant-aware workspace queries

### DIFF
--- a/services/smm-architect/migrations/005_enforce_tenant_rls.sql
+++ b/services/smm-architect/migrations/005_enforce_tenant_rls.sql
@@ -1,0 +1,30 @@
+-- Migration: 005_enforce_tenant_rls.sql
+-- Ensure RLS policies restrict rows by tenant_id
+
+-- Workspaces table
+ALTER TABLE workspaces ENABLE ROW LEVEL SECURITY;
+ALTER TABLE workspaces FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS tenant_isolation_workspaces ON workspaces;
+CREATE POLICY tenant_isolation_workspaces ON workspaces
+    USING (tenant_id = current_setting('app.current_tenant_id', true))
+    WITH CHECK (tenant_id = current_setting('app.current_tenant_id', true));
+
+-- Workspace runs table
+ALTER TABLE workspace_runs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE workspace_runs FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS tenant_isolation_workspace_runs ON workspace_runs;
+CREATE POLICY tenant_isolation_workspace_runs ON workspace_runs
+    USING (
+        EXISTS (
+            SELECT 1 FROM workspaces w
+            WHERE w.workspace_id = workspace_runs.workspace_id
+            AND w.tenant_id = current_setting('app.current_tenant_id', true)
+        )
+    )
+    WITH CHECK (
+        EXISTS (
+            SELECT 1 FROM workspaces w
+            WHERE w.workspace_id = workspace_runs.workspace_id
+            AND w.tenant_id = current_setting('app.current_tenant_id', true)
+        )
+    );

--- a/services/smm-architect/src/main.ts
+++ b/services/smm-architect/src/main.ts
@@ -116,17 +116,17 @@ export const createWorkspace = api(
  */
 export const getWorkspaceStatus = api(
   { method: "GET", path: "/workspaces/:id/status", auth: true },
-  async ({ id }: { id: string }): Promise<WorkspaceStatusResponse> => {
+  async ({ id, tenantId }: { id: string; tenantId: string }): Promise<WorkspaceStatusResponse> => {
     try {
-      log.info("Getting workspace status", { workspaceId: id });
+      log.info("Getting workspace status", { workspaceId: id, tenantId });
 
-      const workspace = await workspaceService.getWorkspace(id);
+      const workspace = await workspaceService.getWorkspace(id, tenantId);
       if (!workspace) {
         throw new Error("Workspace not found");
       }
 
-      const health = await workspaceService.getWorkspaceHealth(id);
-      const metrics = await workspaceService.getWorkspaceMetrics(id);
+      const health = await workspaceService.getWorkspaceHealth(id, tenantId);
+      const metrics = await workspaceService.getWorkspaceMetrics(id, tenantId);
 
       return {
         workspace,
@@ -153,14 +153,15 @@ export const getWorkspaceStatus = api(
  */
 export const approvePromotion = api(
   { method: "POST", path: "/workspaces/:id/approve", auth: true },
-  async ({ id, ...req }: { id: string } & ApprovalRequest): Promise<ApprovalResponse> => {
+  async ({ id, tenantId, ...req }: { id: string; tenantId: string } & ApprovalRequest): Promise<ApprovalResponse> => {
     try {
-      log.info("Processing approval request", { 
-        workspaceId: id, 
-        action: req.action 
+      log.info("Processing approval request", {
+        workspaceId: id,
+        tenantId,
+        action: req.action
       });
 
-      const workspace = await workspaceService.getWorkspace(id);
+      const workspace = await workspaceService.getWorkspace(id, tenantId);
       if (!workspace) {
         throw new Error("Workspace not found");
       }
@@ -171,7 +172,7 @@ export const approvePromotion = api(
       }
 
       // Process the approval
-      const result = await workspaceService.processApproval(id, req);
+      const result = await workspaceService.processApproval(id, tenantId, req);
 
       log.info("Approval processed", { 
         workspaceId: id, 
@@ -200,11 +201,11 @@ export const approvePromotion = api(
  */
 export const simulateCampaign = api(
   { method: "POST", path: "/workspaces/:id/simulate", auth: true },
-  async ({ id, ...req }: { id: string } & SimulationRequest): Promise<SimulationResponse> => {
+  async ({ id, tenantId, ...req }: { id: string; tenantId: string } & SimulationRequest): Promise<SimulationResponse> => {
     try {
-      log.info("Starting campaign simulation", { workspaceId: id });
+      log.info("Starting campaign simulation", { workspaceId: id, tenantId });
 
-      const workspace = await workspaceService.getWorkspace(id);
+      const workspace = await workspaceService.getWorkspace(id, tenantId);
       if (!workspace) {
         throw new Error("Workspace not found");
       }
@@ -239,11 +240,11 @@ export const simulateCampaign = api(
  */
 export const getAuditBundle = api(
   { method: "GET", path: "/workspaces/:id/audit", auth: true },
-  async ({ id }: { id: string }): Promise<AuditBundleResponse> => {
+  async ({ id, tenantId }: { id: string; tenantId: string }): Promise<AuditBundleResponse> => {
     try {
-      log.info("Retrieving audit bundle", { workspaceId: id });
+      log.info("Retrieving audit bundle", { workspaceId: id, tenantId });
 
-      const workspace = await workspaceService.getWorkspace(id);
+      const workspace = await workspaceService.getWorkspace(id, tenantId);
       if (!workspace) {
         throw new Error("Workspace not found");
       }
@@ -289,7 +290,7 @@ export const health = api(
  */
 export const listWorkspaces = api(
   { method: "GET", path: "/workspaces", auth: true },
-  async ({ tenantId }: { tenantId?: string }): Promise<{ workspaces: WorkspaceContract[] }> => {
+  async ({ tenantId }: { tenantId: string }): Promise<{ workspaces: WorkspaceContract[] }> => {
     try {
       log.info("Listing workspaces", { tenantId });
 
@@ -316,11 +317,11 @@ export const listWorkspaces = api(
  */
 export const updateWorkspace = api(
   { method: "PUT", path: "/workspaces/:id", auth: true },
-  async ({ id, contract }: { id: string; contract: Partial<WorkspaceContract> }): Promise<{ updated: boolean }> => {
+  async ({ id, tenantId, contract }: { id: string; tenantId: string; contract: Partial<WorkspaceContract> }): Promise<{ updated: boolean }> => {
     try {
-      log.info("Updating workspace", { workspaceId: id });
+      log.info("Updating workspace", { workspaceId: id, tenantId });
 
-      const result = await workspaceService.updateWorkspace(id, contract);
+      const result = await workspaceService.updateWorkspace(id, tenantId, contract);
 
       log.info("Workspace updated", { workspaceId: id, updated: result });
 
@@ -345,11 +346,11 @@ export const updateWorkspace = api(
  */
 export const deleteWorkspace = api(
   { method: "DELETE", path: "/workspaces/:id", auth: true },
-  async ({ id }: { id: string }): Promise<{ deleted: boolean }> => {
+  async ({ id, tenantId }: { id: string; tenantId: string }): Promise<{ deleted: boolean }> => {
     try {
-      log.info("Decommissioning workspace", { workspaceId: id });
+      log.info("Decommissioning workspace", { workspaceId: id, tenantId });
 
-      const result = await workspaceService.decommissionWorkspace(id);
+      const result = await workspaceService.decommissionWorkspace(id, tenantId);
 
       log.info("Workspace decommissioned", { workspaceId: id });
 

--- a/services/smm-architect/tests/tenant-security.test.ts
+++ b/services/smm-architect/tests/tenant-security.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from '@jest/globals';
+import { WorkspaceService } from '../src/services/workspace-service';
+import { WorkspaceContract } from '../src/types';
+
+class InMemorySQLDatabase {
+  private workspaces: any[] = [];
+
+  async query(sql: string, params: any[] = []): Promise<any[]> {
+    if (sql.includes('WHERE workspace_id = ? AND tenant_id = ?')) {
+      const [workspaceId, tenantId] = params;
+      const row = this.workspaces.find(
+        w => w.workspace_id === workspaceId && w.tenant_id === tenantId
+      );
+      return row ? [{ contract_data: row.contract_data }] : [];
+    }
+    if (sql.includes('WHERE tenant_id = ?')) {
+      const [tenantId] = params;
+      return this.workspaces
+        .filter(w => w.tenant_id === tenantId)
+        .map(w => ({ contract_data: w.contract_data }));
+    }
+    return [];
+  }
+
+  async exec(sql: string, params: any[] = []): Promise<void> {
+    if (sql.startsWith('INSERT INTO workspaces')) {
+      const [workspace_id, tenant_id, created_by, created_at, lifecycle,
+        contract_version, goals, primary_channels, budget, approval_policy,
+        risk_profile, data_retention, ttl_hours, policy_bundle_ref,
+        policy_bundle_checksum, contract_data] = params;
+      this.workspaces.push({
+        workspace_id,
+        tenant_id,
+        created_by,
+        created_at,
+        lifecycle,
+        contract_version,
+        goals,
+        primary_channels,
+        budget,
+        approval_policy,
+        risk_profile,
+        data_retention,
+        ttl_hours,
+        policy_bundle_ref,
+        policy_bundle_checksum,
+        contract_data
+      });
+    } else if (sql.startsWith('UPDATE workspaces')) {
+      const [contract_data, updated_at, workspace_id, tenant_id] = params;
+      const ws = this.workspaces.find(
+        w => w.workspace_id === workspace_id && w.tenant_id === tenant_id
+      );
+      if (ws) {
+        ws.contract_data = contract_data;
+        ws.updated_at = updated_at;
+      }
+    }
+  }
+}
+
+describe('tenant security', () => {
+  it('prevents cross-tenant workspace access (security)', async () => {
+    const db = new InMemorySQLDatabase();
+    const service = new WorkspaceService(db as any);
+
+    const contract: Omit<WorkspaceContract, 'workspaceId' | 'createdAt' | 'lifecycle'> = {
+      tenantId: 'tenant-a',
+      createdBy: 'user@example.com',
+      contractVersion: 'v1',
+      goals: [],
+      primaryChannels: [],
+      budget: { currency: 'USD', weeklyCap: 0, hardCap: 0, breakdown: { paidAds: 0, llmModelSpend: 0, rendering: 0, thirdPartyServices: 0 } },
+      approvalPolicy: { autoApproveReadinessThreshold: 0.8, canaryInitialPct: 0.1, canaryWatchWindowHours: 1, manualApprovalForPaid: false, legalManualApproval: false },
+      riskProfile: 'low',
+      dataRetention: { auditRetentionDays: 30 },
+      ttlHours: 1,
+      policyBundleRef: 'ref',
+      policyBundleChecksum: 'sum'
+    };
+
+    const created = await service.createWorkspace(contract);
+
+    const fetchedSameTenant = await service.getWorkspace(created.workspaceId, 'tenant-a');
+    expect(fetchedSameTenant?.workspaceId).toBe(created.workspaceId);
+
+    const fetchedOtherTenant = await service.getWorkspace(created.workspaceId, 'tenant-b');
+    expect(fetchedOtherTenant).toBeNull();
+
+    const listOtherTenant = await service.listWorkspaces('tenant-b');
+    expect(listOtherTenant.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- require `tenantId` on workspace API endpoints and service queries
- enforce tenant RLS policies in new migration
- add security test preventing cross-tenant data access

## Testing
- `npm test`
- `npm run test:security`


------
https://chatgpt.com/codex/tasks/task_e_68b9912e7ca8832bb4548a31e057e7d9
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Make workspace APIs and queries tenant-aware to enforce strict data isolation. Adds database row-level security to block cross-tenant access.

- **New Features**
  - Require tenantId on all workspace endpoints and service methods.
  - Enforce RLS on workspaces and workspace_runs using app.current_tenant_id.
  - Add tenant_id filters to get/list/update/decommission/metrics queries.
  - Add a security test to prevent cross-tenant data access.

- **Migration**
  - Run migration 005_enforce_tenant_rls.sql.
  - Ensure all API callers include tenantId.
  - Set app.current_tenant_id per DB session/request so RLS allows access for the correct tenant.

<!-- End of auto-generated description by cubic. -->

