### PR TITLE
docs: add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 SMM Architect Team
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SMM Architect
 
 [![CI Status](https://github.com/yourorg/smm-architect/workflows/CI/badge.svg)](https://github.com/yourorg/smm-architect/actions)
-[![License](https://img.shields.io/badge/license-Proprietary-red.svg)](LICENSE)
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Version](https://img.shields.io/badge/version-1.0.0-blue.svg)](CHANGELOG.md)
 [![Status](https://img.shields.io/badge/status-Production%20Ready-brightgreen.svg)](AGENTS.md)
 
@@ -452,8 +452,7 @@ See `examples/workspace-contract.icblabs.json` for a complete example workspace 
 - Test policy changes thoroughly
 
 ## 📄 License
-
-This project is proprietary software. See [LICENSE](LICENSE) for details.
+This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.
 
 ## 🙋‍♀️ Support
 

--- a/services/smm-architect/package.json
+++ b/services/smm-architect/package.json
@@ -52,5 +52,5 @@
     "encore",
     "typescript"
   ],
-  "license": "UNLICENSED"
+  "license": "MIT"
 }


### PR DESCRIPTION
## Summary
- add MIT license file
- update service package to MIT license
- reference license from README

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npx jest@latest` *(fails: Watch plugin jest-watch-typeahead/filename cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_68b986e1fe6c832b8782afaa3091e973
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adopt MIT licensing for the repo by adding a LICENSE file, updating services/smm-architect/package.json to "MIT", and changing the README license badge and text.

<!-- End of auto-generated description by cubic. -->

