### PR TITLE
refactor: enforce env-based Sentry DSN

### DIFF
--- a/services/smm-architect/src/config/sentry.ts
+++ b/services/smm-architect/src/config/sentry.ts
@@ -14,7 +14,7 @@ const log = {
 
 // Sentry configuration
 const sentryConfig = {
-  dsn: process.env.SENTRY_DSN || "https://02a82d6e1d09e631f5ef7083e197c841@o4509899378786304.ingest.de.sentry.io/4509899558879312",
+  dsn: process.env.SENTRY_DSN,
   environment: process.env.NODE_ENV || "development",
   release: process.env.npm_package_version,
   tracesSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1.0,
@@ -24,6 +24,12 @@ const sentryConfig = {
   enableLogs: true,
   sendDefaultPii: false,
 };
+
+if (!sentryConfig.dsn) {
+  const message = "SENTRY_DSN environment variable is required";
+  log.error(message);
+  throw new Error(message);
+}
 
 // Service context
 const serviceContext = {


### PR DESCRIPTION
## Summary
- remove hard-coded Sentry DSN fallback
- require SENTRY_DSN environment variable

## Testing
- `npm test` *(fails: turbo: not found)*
- `make test` *(fails: turbo: not found)*
- `make test-security` *(fails: RLS Policy Requirements missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b986e0cd1c832b9dba941343a4340b
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Enforces Sentry DSN via the SENTRY_DSN environment variable and removes the hard-coded fallback. The service now logs an error and fails fast on startup if SENTRY_DSN is missing.

- **Migration**
  - Set SENTRY_DSN for smm-architect in all environments (prod, staging, dev).
  - Add SENTRY_DSN to local .env and deployment secrets, then redeploy.

<!-- End of auto-generated description by cubic. -->

