### PR TITLE
feat: enforce tenant context for workspace operations

### DIFF
--- a/services/shared/request-context.ts
+++ b/services/shared/request-context.ts
@@ -1,0 +1,25 @@
+import { AsyncLocalStorage } from 'async_hooks';
+
+interface RequestContext {
+  tenantId?: string;
+}
+
+const requestContext = new AsyncLocalStorage<RequestContext>();
+
+export function setTenantId(tenantId: string): void {
+  requestContext.enterWith({ tenantId });
+}
+
+export function getTenantId(): string | undefined {
+  return requestContext.getStore()?.tenantId;
+}
+
+export function runWithContext<T>(context: RequestContext, fn: () => T): T {
+  return requestContext.run(context, fn);
+}
+
+export default {
+  setTenantId,
+  getTenantId,
+  runWithContext,
+};

--- a/services/smm-architect/src/middleware/auth.ts
+++ b/services/smm-architect/src/middleware/auth.ts
@@ -6,6 +6,7 @@ import { Request, Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
 import winston from 'winston';
 import { withTenantContext } from '../../shared/database/client';
+import { setTenantId } from '../../../shared/request-context';
 
 // Mock Prisma client for tenant context
 interface MockPrismaClient {
@@ -271,6 +272,9 @@ export function setAutomaticTenantContext() {
         tenantId,
         // Additional tenant info could be loaded here
       };
+
+      // Propagate tenant ID through request context
+      setTenantId(tenantId);
       
       logger.debug('Tenant context set', {
         tenantId,

--- a/services/smm-architect/tests/tenant-isolation.test.ts
+++ b/services/smm-architect/tests/tenant-isolation.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach } from '@jest/globals';
+
+import { WorkspaceService } from '../src/services/workspace-service';
+import { setTenantId } from '../../shared/request-context';
+import { WorkspaceContract } from '../src/types';
+
+class InMemoryDB {
+  private workspaces: Array<{ workspace_id: string; tenant_id: string; contract_data: string }> = [];
+
+  async query(sql: string, params: any[] = []): Promise<any[]> {
+    if (sql.startsWith('SELECT contract_data FROM workspaces WHERE workspace_id')) {
+      return this.workspaces.filter(
+        w => w.workspace_id === params[0] && w.tenant_id === params[1]
+      );
+    }
+    if (sql.startsWith('SELECT contract_data FROM workspaces WHERE tenant_id')) {
+      return this.workspaces.filter(w => w.tenant_id === params[0]);
+    }
+    return [];
+  }
+
+  async exec(sql: string, params: any[] = []): Promise<void> {
+    if (sql.startsWith('INSERT INTO workspaces')) {
+      this.workspaces.push({
+        workspace_id: params[0],
+        tenant_id: params[1],
+        contract_data: params[15]
+      });
+    }
+  }
+}
+
+function baseContract(tenantId: string): Omit<WorkspaceContract, 'workspaceId' | 'createdAt' | 'lifecycle'> {
+  return {
+    tenantId,
+    createdBy: 'user',
+    contractVersion: '1.0',
+    goals: [{ key: 'reach', target: 100, unit: 'impressions' }],
+    primaryChannels: ['linkedin'],
+    budget: {
+      currency: 'USD',
+      weeklyCap: 1000,
+      hardCap: 5000,
+      breakdown: { paidAds: 0, llmModelSpend: 0, rendering: 0, thirdPartyServices: 0 }
+    },
+    approvalPolicy: {
+      autoApproveReadinessThreshold: 0.9,
+      canaryInitialPct: 0.1,
+      canaryWatchWindowHours: 24,
+      manualApprovalForPaid: false,
+      legalManualApproval: false
+    },
+    riskProfile: 'low',
+    dataRetention: { auditRetentionDays: 30 },
+    ttlHours: 24,
+    policyBundleRef: 'ref',
+    policyBundleChecksum: 'checksum'
+  };
+}
+
+describe('WorkspaceService tenant isolation', () => {
+  let db: InMemoryDB;
+  let service: WorkspaceService;
+
+  beforeEach(() => {
+    db = new InMemoryDB();
+    service = new WorkspaceService(db as any);
+  });
+
+  it('returns workspaces for current tenant only', async () => {
+    setTenantId('tenantA');
+    await service.createWorkspace(baseContract('tenantA'));
+    setTenantId('tenantB');
+    await service.createWorkspace(baseContract('tenantB'));
+
+    setTenantId('tenantA');
+    const listA = await service.listWorkspaces();
+    expect(listA).toHaveLength(1);
+    expect(listA[0].tenantId).toBe('tenantA');
+
+    setTenantId('tenantB');
+    const listB = await service.listWorkspaces();
+    expect(listB).toHaveLength(1);
+    expect(listB[0].tenantId).toBe('tenantB');
+  });
+
+  it('prevents cross-tenant workspace access', async () => {
+    setTenantId('tenantA');
+    const wsA = await service.createWorkspace(baseContract('tenantA'));
+    setTenantId('tenantB');
+    const wsB = await service.createWorkspace(baseContract('tenantB'));
+
+    setTenantId('tenantA');
+    const fetchedB = await service.getWorkspace(wsB.workspaceId);
+    expect(fetchedB).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- propagate tenant ID using request-scoped storage
- scope workspace queries by tenant to honour RLS
- test workspace isolation across tenants

## Testing
- `npm test` (services/smm-architect)
- `make test` *(fails: command exited (1))*
- `make test-security` *(fails: RLS violations reported)*

------
https://chatgpt.com/codex/tasks/task_e_68b986df1bac832b8480ca2edbc8852a
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Enforces tenant-scoped execution for workspace operations using request-scoped context so all DB access honors RLS and blocks cross-tenant access.

- **New Features**
  - Added request context via AsyncLocalStorage (setTenantId/getTenantId/runWithContext).
  - Auth middleware now sets tenantId into the request context.
  - WorkspaceService methods require a tenant context and filter by tenant_id in queries.
  - Endpoints use the request context; POST /workspaces validates contract.tenantId matches the context; GET /workspaces lists only the current tenant.
  - Added tests to verify tenant isolation across list/get paths.

- **Migration**
  - Ensure auth middleware runs before handlers and sets tenantId.
  - GET /workspaces no longer accepts a tenantId param.
  - POST /workspaces requires contract.tenantId to match the current tenant context.

<!-- End of auto-generated description by cubic. -->

