### PR TITLE
feat: enforce auth middleware with tenant checks

### DIFF
--- a/services/smm-architect/package.json
+++ b/services/smm-architect/package.json
@@ -26,11 +26,15 @@
     "@google-cloud/kms": "^4.0.0",
     "node-vault": "^0.10.0",
     "ajv": "^8.12.0",
+    "ajv-formats": "^2.1.1",
     "winston": "^3.11.0",
     "uuid": "^9.0.0",
     "date-fns": "^2.30.0",
     "@sentry/node": "^7.99.0",
-    "@sentry/profiling-node": "^7.99.0"
+    "@sentry/profiling-node": "^7.99.0",
+    "jsonwebtoken": "^9.0.2",
+    "express": "^4.18.2",
+    "cors": "^2.8.5"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
@@ -42,7 +46,9 @@
     "jest": "^29.7.0",
     "ts-jest": "^29.1.0",
     "typescript": "^5.2.0",
-
+    "@types/jsonwebtoken": "^9.0.2",
+    "@types/express": "^4.17.21",
+    "@types/cors": "^2.8.17",
     "nock": "^13.3.3"
   },
   "keywords": [

--- a/services/smm-architect/src/main.ts
+++ b/services/smm-architect/src/main.ts
@@ -5,8 +5,15 @@ interface ApiConfig {
   auth?: boolean;
 }
 
+import { authenticate, AuthenticatedRequest } from "./middleware/auth-middleware";
+
 function api(config: ApiConfig, handler: (req: any) => Promise<any>) {
-  return handler;
+  return async (req: AuthenticatedRequest): Promise<any> => {
+    if (config.auth) {
+      authenticate(req);
+    }
+    return handler(req);
+  };
 }
 
 // Mock SQLDatabase implementation

--- a/services/smm-architect/src/middleware/auth-middleware.ts
+++ b/services/smm-architect/src/middleware/auth-middleware.ts
@@ -1,0 +1,40 @@
+import jwt from 'jsonwebtoken';
+import { APIError } from '../types';
+
+export interface AuthenticatedRequest {
+  headers?: Record<string, string>;
+  user?: { userId: string; tenantId: string };
+  tenantId?: string;
+}
+
+const JWT_SECRET = process.env.JWT_SECRET || 'test-secret';
+
+/**
+ * Basic JWT authentication ensuring user and tenant context
+ */
+export function authenticate(req: AuthenticatedRequest): void {
+  const authHeader = req.headers?.authorization;
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    throw { code: 'UNAUTHORIZED', message: 'Missing or invalid authorization header' } as APIError;
+  }
+
+  const token = authHeader.substring(7);
+  try {
+    const payload = jwt.verify(token, JWT_SECRET) as any;
+    const userId = payload.sub;
+    const tenantId = payload.tenantId;
+    if (!userId || !tenantId) {
+      throw new Error('Invalid token payload');
+    }
+    if (req.tenantId && req.tenantId !== tenantId) {
+      throw { code: 'FORBIDDEN', message: 'Tenant mismatch' } as APIError;
+    }
+    req.user = { userId, tenantId };
+    req.tenantId = tenantId;
+  } catch (error) {
+    if ((error as APIError).code) {
+      throw error;
+    }
+    throw { code: 'UNAUTHORIZED', message: 'Invalid authentication token' } as APIError;
+  }
+}

--- a/services/smm-architect/tests/auth.test.ts
+++ b/services/smm-architect/tests/auth.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from '@jest/globals';
+import jwt from 'jsonwebtoken';
+import { listWorkspaces } from '../src/main';
+
+describe('Authentication middleware', () => {
+  const secret = process.env.JWT_SECRET || 'test-secret';
+  const validToken = jwt.sign({ sub: 'user1', tenantId: 'tenant1' }, secret);
+
+  it('rejects requests without authorization header', async () => {
+    await expect(listWorkspaces({ tenantId: 'tenant1' })).rejects.toEqual({
+      code: 'UNAUTHORIZED',
+      message: 'Missing or invalid authorization header'
+    });
+  });
+
+  it('rejects requests with tenant mismatch', async () => {
+    await expect(
+      listWorkspaces({ tenantId: 'other-tenant', headers: { authorization: `Bearer ${validToken}` } })
+    ).rejects.toEqual({ code: 'FORBIDDEN', message: 'Tenant mismatch' });
+  });
+
+  it('allows requests with valid token and tenant', async () => {
+    const response = await listWorkspaces({
+      tenantId: 'tenant1',
+      headers: { authorization: `Bearer ${validToken}` }
+    });
+    expect(response).toEqual({ workspaces: [] });
+  });
+});

--- a/services/smm-architect/tests/setup.ts
+++ b/services/smm-architect/tests/setup.ts
@@ -5,6 +5,7 @@ import { jest } from '@jest/globals';
 process.env.NODE_ENV = 'test';
 process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/smm_architect_test';
 process.env.REDIS_URL = 'redis://localhost:6379';
+process.env.JWT_SECRET = 'test-secret';
 
 // Mock console methods to reduce noise in tests
 const originalConsole = global.console;


### PR DESCRIPTION
## Summary
- add JWT authentication middleware enforcing user and tenant validation
- wire middleware into API wrapper for all routes flagged with auth
- cover authorized and unauthorized requests with new tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b986de64b0832b83123e8f45cab0b3