### PR TITLE
Replace demo user data with placeholders and warnings

### DIFF
--- a/apps/frontend/src/components/navigation.tsx
+++ b/apps/frontend/src/components/navigation.tsx
@@ -86,12 +86,13 @@ export function Navigation() {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
   const pathname = usePathname()
   
-  // Mock user data - in real app this would come from auth context
+  // Mock user data for development/testing only.
+  // WARNING: Do not use these demo credentials in production.
   const user = {
-    name: "John Doe",
-    email: "john@company.com",
+    name: "Example User",
+    email: "user@example.invalid",
     role: "admin",
-    avatar: "/avatars/john-doe.jpg",
+    avatar: "/avatars/example-user.jpg",
   }
 
   const filteredNavItems = navigationItems.filter(

--- a/apps/frontend/src/components/ui/timeline.stories.tsx
+++ b/apps/frontend/src/components/ui/timeline.stories.tsx
@@ -45,7 +45,7 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-// Sample data
+// Sample data (demo values - do not use in production)
 const basicSteps: TimelineStep[] = [
   {
     id: 'step1',
@@ -95,7 +95,7 @@ const workflowSteps: TimelineStep[] = [
     description: 'Document draft has been created',
     status: 'completed',
     timestamp: new Date('2024-01-01T09:00:00Z'),
-    metadata: { author: 'John Doe', version: '1.0' }
+    metadata: { author: 'Example Author', version: '1.0' }
   },
   {
     id: 'review',
@@ -104,7 +104,7 @@ const workflowSteps: TimelineStep[] = [
     status: 'completed',
     timestamp: new Date('2024-01-01T09:30:00Z'),
     duration: '2 hours',
-    metadata: { reviewers: ['Alice', 'Bob'], comments: 3 }
+    metadata: { reviewers: ['Reviewer A', 'Reviewer B'], comments: 3 }
   },
   {
     id: 'approval',

--- a/docs/operational-runbooks.md
+++ b/docs/operational-runbooks.md
@@ -19,13 +19,15 @@
 
 ### 🚨 Critical Incident Response Team
 
+> **Warning:** Contact information below uses placeholders. Replace with real details in production.
+
 | Role | Contact | Phone | Primary Responsibilities |
 |------|---------|-------|-------------------------|
-| **Incident Commander** | ops-lead@company.com | +1-555-0001 | Overall incident coordination |
-| **Security Lead** | security@company.com | +1-555-0002 | Security incidents, data breaches |
-| **DevOps Engineer** | devops@company.com | +1-555-0003 | Infrastructure, deployments |
-| **Database Admin** | dba@company.com | +1-555-0004 | Database issues, performance |
-| **Product Owner** | product@company.com | +1-555-0005 | Business impact assessment |
+| **Incident Commander** | ops@example.com | +1-555-0001 | Overall incident coordination |
+| **Security Lead** | security@example.com | +1-555-0002 | Security incidents, data breaches |
+| **DevOps Engineer** | devops@example.com | +1-555-0003 | Infrastructure, deployments |
+| **Database Admin** | dba@example.com | +1-555-0004 | Database issues, performance |
+| **Product Owner** | product@example.com | +1-555-0005 | Business impact assessment |
 
 ### 📋 Escalation Matrix
 
@@ -584,7 +586,7 @@ For immediate assistance during incidents:
 
 - **Slack**: #smm-architect-incidents
 - **PagerDuty**: SMM Architect Service
-- **Email**: incidents@company.com
+- **Email**: incidents@example.com
 - **Escalation**: +1-555-URGENT
 
 **Remember**: 

--- a/docs/workspace-contract.md
+++ b/docs/workspace-contract.md
@@ -2,6 +2,8 @@
 
 ## Overview
 
+> **Warning:** Example values in this document are placeholders for demonstration. Replace all demo data before using in production.
+
 The **WorkspaceContract** is the authoritative, signed, declarative specification that defines workspace behavior, goals, and constraints within the SMM Architect platform. It serves as the single source of truth for all workspace-related policies, configurations, and operational parameters.
 
 ## Purpose
@@ -47,9 +49,10 @@ stateDiagram-v2
 
 ```json
 {
+  // Example values only; replace with real workspace IDs and emails.
   "workspaceId": "ws-{tenant}-{uuid8}",
   "tenantId": "tenant-organization-id",
-  "createdBy": "user:alice@company.com",
+  "createdBy": "user:alice@example.com",
   "createdAt": "2025-08-24T10:00:00Z",
   "contractVersion": "v1.2.3",
   "lifecycle": "active"
@@ -65,9 +68,10 @@ stateDiagram-v2
 
 ```json
 {
+  // Example signature metadata. Replace with real signer details.
   "signedBy": {
-    "principal": "user:alice@company.com",
-    "signedAt": "2025-08-24T10:30:00Z", 
+    "principal": "user:alice@example.com",
+    "signedAt": "2025-08-24T10:30:00Z",
     "signatureId": "sig-icb-001-a7f9d2e1"
   },
   "effectiveFrom": "2025-08-24T11:00:00Z",
@@ -108,6 +112,7 @@ Supported goal types:
 
 ```json
 {
+  // Example connector configuration; replace with production values.
   "primaryChannels": ["linkedin", "x", "instagram"],
   "connectors": [
     {
@@ -118,7 +123,7 @@ Supported goal types:
       "status": "connected",
       "lastConnectedAt": "2025-08-24T09:45:00Z",
       "scopes": ["w_member_social", "r_basicprofile"],
-      "ownerContact": "social@company.com"
+      "ownerContact": "social@example.com"
     }
   ]
 }
@@ -182,11 +187,12 @@ Supported goal types:
 
 ```json
 {
+  // Example consent record; replace with real authorization data.
   "consentRecords": [
     {
       "consentId": "consent-voice-001",
       "type": "voice_likeness",
-      "grantedBy": "user:spokesperson@company.com",
+      "grantedBy": "user:spokesperson@example.com",
       "grantedAt": "2025-08-24T10:15:00Z",
       "expiresAt": "2026-08-24T10:15:00Z",
       "documentRef": "s3://consents/voice-likeness-001.pdf",

--- a/services/toolhub/src/routes/oauth.ts
+++ b/services/toolhub/src/routes/oauth.ts
@@ -250,16 +250,17 @@ router.get('/connections/:workspaceId',
       }
 
       // Database query for OAuth connections will be implemented with production database setup
-      // For now, return mock data
+      // Demo connection data below is for development/testing only.
+      // WARNING: Replace these placeholders with real data in production.
       const connections = [
         {
           connectionId: 'conn-linkedin-001',
           platform: 'linkedin',
           profile: {
-            id: '123456789',
-            name: 'John Doe',
-            username: 'johndoe',
-            profileUrl: 'https://linkedin.com/in/johndoe'
+            id: '000000000',
+            name: 'Example User',
+            username: 'exampleuser',
+            profileUrl: 'https://linkedin.com/in/exampleuser'
           },
           scopes: ['r_liteprofile', 'w_member_social'],
           connectedAt: '2024-01-15T10:30:00Z',

--- a/tests/security/security-tests.test.ts
+++ b/tests/security/security-tests.test.ts
@@ -427,10 +427,12 @@ describe('End-to-End Security Testing', () => {
 
   describe('Cryptographic Security Tests', () => {
     it('should use secure encryption for sensitive data', async () => {
+      // Demo values for encryption test only.
+      // WARNING: Never use these placeholders in production systems.
       const sensitiveData = {
-        apiKey: 'sk-1234567890abcdef',
+        apiKey: 'sk-demo-000000000000',
         password: 'user-password-123',
-        personalInfo: 'john.doe@example.com'
+        personalInfo: 'demo.user@example.invalid'
       };
 
       const encryptionTest = await securitySuite.testEncryption(sensitiveData);

--- a/tests/unit/structured-logging.test.ts
+++ b/tests/unit/structured-logging.test.ts
@@ -125,9 +125,10 @@ describe('StructuredLogger', () => {
 
   describe('PII Masking', () => {
     it('should mask email addresses', () => {
+      // Demo emails for testing; never use in production logs.
       const dataWithEmail = {
         userEmail: 'user@example.com',
-        contactInfo: 'Contact us at support@company.com'
+        contactInfo: 'Contact us at support@example.com'
       };
 
       logger.info('Processing user data', dataWithEmail);
@@ -135,7 +136,7 @@ describe('StructuredLogger', () => {
       const logCall = mockConsole.info.mock.calls[0][0];
       expect(logCall).toContain('[EMAIL_MASKED]');
       expect(logCall).not.toContain('user@example.com');
-      expect(logCall).not.toContain('support@company.com');
+      expect(logCall).not.toContain('support@example.com');
     });
 
     it('should mask phone numbers', () => {


### PR DESCRIPTION
## Summary
- replace mock user data with clearly fictitious placeholders across frontend, services, tests, and docs
- add comments warning developers not to use demo values in production
- ensure structured logging tests use placeholder contact info and verify sensitive fields are masked

## Testing
- `make test` *(fails: command (/workspace/smm-architect/packages/ui) pnpm run build exited (1))*
- `make test-security` *(fails: make: *** [Makefile:44: test-security] Error 1)*
- `npx jest tests/unit/structured-logging.test.ts` *(fails: SyntaxError: Invalid regular expression /\(?\d{3}\)?[-\s.]?\d{3}[-\s.]?\d{4}/g: Invalid group)*

------
https://chatgpt.com/codex/tasks/task_e_68b986dd1364832b8f0485aef7eacd07
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Replaced all demo user data with clear placeholders and added warnings to prevent accidental use in production. Updated docs, UI stories, OAuth mock data, and tests to use example values and reinforce PII masking.

- **Refactors**
  - Frontend: swapped mock user to “Example User” with user@example.invalid and added warnings; updated timeline stories with neutral names.
  - Services: OAuth connections route now returns placeholder profiles with explicit do-not-use notices.
  - Docs: runbooks and workspace contract switched to example.com addresses and added prominent replacement warnings.
  - Tests: security and structured-logging tests use example/invalid data and assertions confirm PII masking.

<!-- End of auto-generated description by cubic. -->

