### PR TITLE
feat: enforce node version

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -9,6 +9,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  NODE_VERSION: '18'
 
 jobs:
   # Pipeline stages: build test deploy
@@ -17,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [${{ env.NODE_VERSION }}]
     
     steps:
     - uses: actions/checkout@v4

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "description": "QA & Validation framework for SMM Architect",
   "packageManager": "pnpm@8.15.0",
+  "engines": {
+    "node": ">=18"
+  },
   "scripts": {
     "build": "turbo build",
     "dev": "turbo dev",


### PR DESCRIPTION
## Summary
- specify Node.js runtime with engines field
- align CI pipeline to use Node 18 via NODE_VERSION env

## Testing
- `make test` *(fails: command (/workspace/smm-architect/packages/ui) pnpm run build exited)*
- `make test-security` *(fails: RLS linting reports missing row-level security policies)*

------
https://chatgpt.com/codex/tasks/task_e_68b986daa32c832bb432c73df485336e
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Enforced a consistent Node.js runtime by pinning CI to Node 18 and declaring "engines": { "node": ">=18" } in package.json to prevent version drift.

- **Migration**
  - Use Node >=18 locally; Node 18 is recommended to match CI.

<!-- End of auto-generated description by cubic. -->

