### PR TITLE
chore: use env-based Sentry DSN

### DIFF
--- a/apps/frontend/sentry.client.config.ts
+++ b/apps/frontend/sentry.client.config.ts
@@ -1,7 +1,15 @@
 import * as Sentry from "@sentry/nextjs";
 
+const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
+
+if (!dsn) {
+  // eslint-disable-next-line no-console
+  console.warn("Sentry DSN not provided. Client-side monitoring disabled.");
+}
+
 Sentry.init({
-  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN || "https://02a82d6e1d09e631f5ef7083e197c841@o4509899378786304.ingest.de.sentry.io/4509899558879312",
+  dsn,
+  enabled: !!dsn,
   
   // Adjust this value in production, or use tracesSampler for greater control
   tracesSampleRate: process.env.NODE_ENV === 'production' ? 0.1 : 1.0,

--- a/apps/frontend/sentry.edge.config.ts
+++ b/apps/frontend/sentry.edge.config.ts
@@ -1,7 +1,15 @@
 import * as Sentry from "@sentry/nextjs";
 
+const dsn = process.env.SENTRY_DSN;
+
+if (!dsn) {
+  // eslint-disable-next-line no-console
+  console.warn("Sentry DSN not provided. Edge monitoring disabled.");
+}
+
 Sentry.init({
-  dsn: process.env.SENTRY_DSN || "https://02a82d6e1d09e631f5ef7083e197c841@o4509899378786304.ingest.de.sentry.io/4509899558879312",
+  dsn,
+  enabled: !!dsn,
   
   // Adjust this value in production, or use tracesSampler for greater control
   tracesSampleRate: process.env.NODE_ENV === 'production' ? 0.1 : 1.0,

--- a/apps/frontend/sentry.server.config.ts
+++ b/apps/frontend/sentry.server.config.ts
@@ -1,7 +1,15 @@
 import * as Sentry from "@sentry/nextjs";
 
+const dsn = process.env.SENTRY_DSN;
+
+if (!dsn) {
+  // eslint-disable-next-line no-console
+  console.warn("Sentry DSN not provided. Server-side monitoring disabled.");
+}
+
 Sentry.init({
-  dsn: process.env.SENTRY_DSN || "https://02a82d6e1d09e631f5ef7083e197c841@o4509899378786304.ingest.de.sentry.io/4509899558879312",
+  dsn,
+  enabled: !!dsn,
   
   // Adjust this value in production, or use tracesSampler for greater control
   tracesSampleRate: process.env.NODE_ENV === 'production' ? 0.1 : 1.0,

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -100,6 +100,7 @@ PINECONE_API_KEY=your-pinecone-key
 
 # Monitoring
 SENTRY_DSN=your-sentry-dsn
+NEXT_PUBLIC_SENTRY_DSN=your-sentry-dsn
 PROMETHEUS_URL=http://localhost:9090
 
 # n8n Configuration

--- a/docs/sentry-configuration.md
+++ b/docs/sentry-configuration.md
@@ -18,7 +18,8 @@ SMM Architect uses Sentry across multiple components:
 
 All services use the following environment variables:
 
-- `SENTRY_DSN` - The Data Source Name for your Sentry project
+- `SENTRY_DSN` - The Data Source Name for your Sentry project. If unset, services log a warning and skip Sentry initialization.
+- `NEXT_PUBLIC_SENTRY_DSN` - Browser DSN for the frontend application. If unset, client monitoring is disabled.
 - `SENTRY_ORG` - Your Sentry organization name (for source map uploads)
 - `SENTRY_PROJECT` - Your Sentry project name (for source map uploads)
 - `SENTRY_AUTH_TOKEN` - Authentication token for source map uploads

--- a/docs/sentry-setup-complete.md
+++ b/docs/sentry-setup-complete.md
@@ -30,7 +30,7 @@
 ## 🎯 Your Sentry Project Details
 
 ```
-DSN: https://02a82d6e1d09e631f5ef7083e197c841@o4509899378786304.ingest.de.sentry.io/4509899558879312
+DSN: <your-sentry-dsn>
 Organization ID: 4509899378786304
 Project Name: smm-architect
 Platform: Express/Node.js
@@ -52,8 +52,8 @@ Add these to your environment (or use the `.env.example` file):
 
 ```bash
 # Required
-SENTRY_DSN=https://02a82d6e1d09e631f5ef7083e197c841@o4509899378786304.ingest.de.sentry.io/4509899558879312
-NEXT_PUBLIC_SENTRY_DSN=https://02a82d6e1d09e631f5ef7083e197c841@o4509899378786304.ingest.de.sentry.io/4509899558879312
+SENTRY_DSN=<your-sentry-dsn>
+NEXT_PUBLIC_SENTRY_DSN=<your-sentry-dsn>
 
 # Optional
 SENTRY_ENABLED=true

--- a/instrument.js
+++ b/instrument.js
@@ -18,9 +18,14 @@ if (nodeProfilingIntegration) {
   integrations.push(nodeProfilingIntegration());
 }
 
-Sentry.init({
-  dsn: "https://02a82d6e1d09e631f5ef7083e197c841@o4509899378786304.ingest.de.sentry.io/4509899558879312",
-  integrations: integrations,
+const dsn = process.env.SENTRY_DSN;
+
+if (!dsn) {
+  console.warn("Sentry DSN not provided. Monitoring disabled.");
+} else {
+  Sentry.init({
+    dsn,
+    integrations: integrations,
   // Tracing
   tracesSampleRate: process.env.NODE_ENV === 'production' ? 0.1 : 1.0,
   // Set sampling rate for profiling - this is evaluated only once per SDK.init call
@@ -53,6 +58,7 @@ Sentry.init({
     
     return event;
   },
-});
+  });
+}
 
 module.exports = Sentry;

--- a/services/audit/src/config/sentry.ts
+++ b/services/audit/src/config/sentry.ts
@@ -1,8 +1,10 @@
 import { initializeSentry } from "../../shared/sentry-utils";
 
 // Sentry configuration
+const dsn = process.env['SENTRY_DSN'];
+
 const sentryConfig = {
-  dsn: process.env['SENTRY_DSN'] || "",
+  dsn,
   environment: process.env['NODE_ENV'] || "development",
   release: process.env['npm_package_version'],
   tracesSampleRate: process.env['NODE_ENV'] === "production" ? 0.1 : 1.0,
@@ -20,8 +22,12 @@ const serviceContext = {
 
 // Initialize Sentry
 try {
-  initializeSentry(sentryConfig, serviceContext);
-  console.log("Sentry initialized for audit service");
+  if (!dsn) {
+    console.warn("Sentry DSN not provided. Skipping Sentry initialization.");
+  } else {
+    initializeSentry(sentryConfig, serviceContext);
+    console.log("Sentry initialized for audit service");
+  }
 } catch (error) {
   console.error("Failed to initialize Sentry", error);
 }

--- a/services/model-router/src/config/sentry.ts
+++ b/services/model-router/src/config/sentry.ts
@@ -13,8 +13,10 @@ const log = {
 };
 
 // Sentry configuration
+const dsn = process.env.SENTRY_DSN;
+
 const sentryConfig = {
-  dsn: process.env.SENTRY_DSN || "https://02a82d6e1d09e631f5ef7083e197c841@o4509899378786304.ingest.de.sentry.io/4509899558879312",
+  dsn,
   environment: process.env.NODE_ENV || "development",
   release: process.env.npm_package_version,
   tracesSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1.0,
@@ -34,8 +36,12 @@ const serviceContext = {
 
 // Initialize Sentry
 try {
-  initializeSentry(sentryConfig, serviceContext);
-  log.info("Sentry initialized for model-router service");
+  if (!dsn) {
+    log.warn("Sentry DSN not provided. Skipping Sentry initialization.");
+  } else {
+    initializeSentry(sentryConfig, serviceContext);
+    log.info("Sentry initialized for model-router service");
+  }
 } catch (error) {
   log.error("Failed to initialize Sentry", error);
 }

--- a/services/simulator/src/config/sentry.ts
+++ b/services/simulator/src/config/sentry.ts
@@ -1,8 +1,10 @@
 import { initializeSentry } from "../shared/sentry-utils";
 
 // Sentry configuration
+const dsn = process.env.SENTRY_DSN;
+
 const sentryConfig = {
-  dsn: process.env.SENTRY_DSN || "",
+  dsn,
   environment: process.env.NODE_ENV || "development",
   release: process.env.npm_package_version,
   tracesSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1.0,
@@ -20,8 +22,12 @@ const serviceContext = {
 
 // Initialize Sentry
 try {
-  initializeSentry(sentryConfig, serviceContext);
-  console.log("Sentry initialized for simulator service");
+  if (!dsn) {
+    console.warn("Sentry DSN not provided. Skipping Sentry initialization.");
+  } else {
+    initializeSentry(sentryConfig, serviceContext);
+    console.log("Sentry initialized for simulator service");
+  }
 } catch (error) {
   console.error("Failed to initialize Sentry", error);
 }

--- a/services/smm-architect/src/config/sentry.ts
+++ b/services/smm-architect/src/config/sentry.ts
@@ -13,8 +13,10 @@ const log = {
 };
 
 // Sentry configuration
+const dsn = process.env.SENTRY_DSN;
+
 const sentryConfig = {
-  dsn: process.env.SENTRY_DSN || "https://02a82d6e1d09e631f5ef7083e197c841@o4509899378786304.ingest.de.sentry.io/4509899558879312",
+  dsn,
   environment: process.env.NODE_ENV || "development",
   release: process.env.npm_package_version,
   tracesSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1.0,
@@ -34,8 +36,12 @@ const serviceContext = {
 
 // Initialize Sentry
 try {
-  initializeSentry(sentryConfig, serviceContext);
-  log.info("Sentry initialized for smm-architect service");
+  if (!dsn) {
+    log.warn("Sentry DSN not provided. Skipping Sentry initialization.");
+  } else {
+    initializeSentry(sentryConfig, serviceContext);
+    log.info("Sentry initialized for smm-architect service");
+  }
 } catch (error) {
   log.error("Failed to initialize Sentry", { error: error instanceof Error ? error.message : String(error) });
 }

--- a/services/toolhub/src/config/sentry.ts
+++ b/services/toolhub/src/config/sentry.ts
@@ -10,8 +10,10 @@ function initializeSentry(config: any) {
 import winston from 'winston';
 
 // Sentry configuration
+const dsn = process.env.SENTRY_DSN;
+
 const sentryConfig = {
-  dsn: process.env.SENTRY_DSN || "",
+  dsn,
   environment: process.env.NODE_ENV || "development",
   release: process.env.npm_package_version,
   tracesSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1.0,
@@ -29,7 +31,11 @@ const serviceContext = {
 
 // Initialize Sentry
 try {
-  initializeSentry(sentryConfig);
+  if (!dsn) {
+    console.warn("Sentry DSN not provided. Skipping Sentry initialization.");
+  } else {
+    initializeSentry(sentryConfig);
+  }
 } catch (error) {
   // Log to console if Sentry fails to initialize
   const errorMessage = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## Summary
- read Sentry DSN from environment instead of hard-coding values
- warn and skip initialization when Sentry DSN is missing
- document SENTRY_DSN and NEXT_PUBLIC_SENTRY_DSN environment variables

## Testing
- `node node_modules/turbo/bin/turbo test` *(fails: smm-architect-service:build exited (1))*
- `make test` *(fails: turbo: not found)*
- `make test-security` *(fails: Error 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b986d98c88832badff8e508126ff56
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Switch Sentry to use environment-provided DSNs instead of hard-coded values across the frontend and services. If a DSN is missing, we log a warning and skip Sentry initialization.

- **Refactors**
  - Frontend client/server/edge configs read DSNs from NEXT_PUBLIC_SENTRY_DSN/SENTRY_DSN and set enabled via truthy check.
  - Services and instrument.js read SENTRY_DSN and guard initialization with warnings when unset.
  - Docs updated to add SENTRY_DSN and NEXT_PUBLIC_SENTRY_DSN and replace hard-coded example DSNs with placeholders.

- **Migration**
  - Set SENTRY_DSN for backend/services and NEXT_PUBLIC_SENTRY_DSN for the browser.
  - If unset, Sentry is disabled; no other behavior changes.

<!-- End of auto-generated description by cubic. -->

