### PR TITLE
feat: secure redis credential handling

### DIFF
--- a/docker-compose.secure.yml
+++ b/docker-compose.secure.yml
@@ -47,14 +47,12 @@ services:
     container_name: smm-redis
     restart: unless-stopped
     command: >
-      redis-server
-      --requirepass "${REDIS_PASSWORD}"
-      --maxmemory 256mb
-      --maxmemory-policy allkeys-lru
-      --save 60 1
-      --loglevel warning
-    environment:
-      REDIS_PASSWORD_FILE: /run/secrets/redis_password
+      sh -c "echo \"requirepass $(cat /run/secrets/redis_password)\" > /tmp/redis.conf && \
+      redis-server /tmp/redis.conf \
+      --maxmemory 256mb \
+      --maxmemory-policy allkeys-lru \
+      --save 60 1 \
+      --loglevel warning"
     secrets:
       - redis_password
     volumes:
@@ -97,12 +95,14 @@ services:
       PORT: 4000
       DATABASE_URL_FILE: /run/secrets/database_url
       REDIS_URL_FILE: /run/secrets/redis_url
+      REDIS_PASSWORD_FILE: /run/secrets/redis_password
       JWT_SECRET_FILE: /run/secrets/jwt_secret
       LOG_LEVEL: info
       METRICS_ENABLED: true
     secrets:
       - database_url
       - redis_url
+      - redis_password
       - jwt_secret
     ports:
       - "4000:4000"


### PR DESCRIPTION
## Summary
- Load Redis password from environment variable or secret file at runtime
- Remove Redis password from command-line arguments in secure Docker configuration
- Pass Redis password secret to services

## Testing
- `make test` *(fails: turbo not found)*
- `make test-security` *(fails: RLS violations in migrations)*

------
https://chatgpt.com/codex/tasks/task_e_68b986d80374832b860f705baf2c02c6
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Secure Redis credential handling by loading the password from an env var or secret file, removing it from command-line flags. Docker Compose and services now read Redis secrets to avoid exposure in logs and process lists.

- **New Features**
  - Added getRedisPassword in DSR, Publisher (server and service), and SMM Architect webhook middleware.
  - Redis clients read password from REDIS_PASSWORD or REDIS_PASSWORD_FILE.
  - docker-compose.secure.yml: start Redis with a generated config file from the secret; pass redis_password secret to services. 

- **Migration**
  - Create and mount a docker secret named redis_password.
  - Set REDIS_PASSWORD_FILE=/run/secrets/redis_password for services (or provide REDIS_PASSWORD).
  - Remove any deployments that pass --requirepass via command-line; Redis is now configured via file.

<!-- End of auto-generated description by cubic. -->

