### PR TITLE
chore: pin container image versions

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -6,7 +6,7 @@ services:
     build:
       context: .
       dockerfile: services/smm-architect/Dockerfile
-    image: smm-architect/core:latest
+    image: smm-architect/core:1.0.0
     ports:
       - "4000:4000"
     environment:
@@ -45,7 +45,7 @@ services:
     build:
       context: .
       dockerfile: services/toolhub/Dockerfile
-    image: smm-architect/toolhub:latest
+    image: smm-architect/toolhub:1.0.0
     ports:
       - "3001:3001"
     environment:
@@ -84,7 +84,7 @@ services:
     build:
       context: .
       dockerfile: apps/frontend/Dockerfile
-    image: smm-architect/frontend:latest
+    image: smm-architect/frontend:1.0.0
     ports:
       - "3000:3000"
     environment:
@@ -132,7 +132,7 @@ services:
 
   # Monitoring
   prometheus:
-    image: prom/prometheus:latest
+    image: prom/prometheus:v2.45.0
     ports:
       - "9090:9090"
     volumes:
@@ -150,7 +150,7 @@ services:
     restart: unless-stopped
 
   grafana:
-    image: grafana/grafana:latest
+    image: grafana/grafana:10.4.3
     ports:
       - "3001:3000"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,7 +132,7 @@ services:
 
   # Monitoring Services
   prometheus:
-    image: prom/prometheus:latest
+    image: prom/prometheus:v2.45.0
     container_name: smm-prometheus
     ports:
       - "9090:9090"
@@ -150,7 +150,7 @@ services:
     restart: unless-stopped
 
   grafana:
-    image: grafana/grafana:latest
+    image: grafana/grafana:10.4.3
     container_name: smm-grafana
     ports:
       - "3001:3000"
@@ -165,7 +165,7 @@ services:
 
   # Development Tools
   mailhog:
-    image: mailhog/mailhog:latest
+    image: mailhog/mailhog:v1.0.1
     container_name: smm-mailhog
     ports:
       - "8025:8025"  # Web interface

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -667,7 +667,7 @@ N8N_BASIC_AUTH_PASSWORD=admin
 3. **Security Updates**
    ```bash
    # Scan for vulnerabilities
-   trivy image smm-architect/smm-architect-service:latest
+   trivy image smm-architect/smm-architect-service:1.0.0
    
    # Update base images
    docker build --pull -t smm-architect/smm-architect-service:v1.0.1 .

--- a/infrastructure/base/terraform/workspace-module/variables.tf
+++ b/infrastructure/base/terraform/workspace-module/variables.tf
@@ -195,7 +195,7 @@ variable "redis_storage_size" {
 variable "workspace_api_image" {
   description = "Docker image for workspace API"
   type        = string
-  default     = "smm-architect/workspace-api:latest"
+  default     = "smm-architect/workspace-api:1.0.0"
 }
 
 variable "workspace_api_replicas" {

--- a/infrastructure/kubernetes/10-smm-architect-service.yaml
+++ b/infrastructure/kubernetes/10-smm-architect-service.yaml
@@ -27,7 +27,7 @@ spec:
         fsGroup: 1001
       containers:
       - name: smm-architect
-        image: smm-architect/core:latest
+        image: smm-architect/core:1.0.0
         imagePullPolicy: Always
         ports:
         - containerPort: 4000

--- a/infrastructure/kubernetes/11-toolhub-service.yaml
+++ b/infrastructure/kubernetes/11-toolhub-service.yaml
@@ -27,7 +27,7 @@ spec:
         fsGroup: 1001
       containers:
       - name: toolhub
-        image: smm-architect/toolhub:latest
+        image: smm-architect/toolhub:1.0.0
         imagePullPolicy: Always
         ports:
         - containerPort: 3001

--- a/infrastructure/kubernetes/12-frontend-service.yaml
+++ b/infrastructure/kubernetes/12-frontend-service.yaml
@@ -27,7 +27,7 @@ spec:
         fsGroup: 1001
       containers:
       - name: frontend
-        image: smm-architect/frontend:latest
+        image: smm-architect/frontend:1.0.0
         imagePullPolicy: Always
         ports:
         - containerPort: 3000

--- a/infrastructure/kubernetes/13-model-router-service.yaml
+++ b/infrastructure/kubernetes/13-model-router-service.yaml
@@ -29,7 +29,7 @@ spec:
         fsGroup: 1001
       containers:
       - name: model-router
-        image: smm-architect/model-router:latest
+        image: smm-architect/model-router:1.0.0
         imagePullPolicy: Always
         ports:
         - containerPort: 3002

--- a/infrastructure/kubernetes/14-publisher-service.yaml
+++ b/infrastructure/kubernetes/14-publisher-service.yaml
@@ -29,7 +29,7 @@ spec:
         fsGroup: 1001
       containers:
       - name: publisher
-        image: smm-architect/publisher:latest
+        image: smm-architect/publisher:1.0.0
         imagePullPolicy: Always
         ports:
         - containerPort: 3003

--- a/infrastructure/kubernetes/15-agents-service.yaml
+++ b/infrastructure/kubernetes/15-agents-service.yaml
@@ -29,7 +29,7 @@ spec:
         fsGroup: 1001
       containers:
       - name: agents
-        image: smm-architect/agents:latest
+        image: smm-architect/agents:1.0.0
         imagePullPolicy: Always
         ports:
         - containerPort: 3004

--- a/infrastructure/kubernetes/helm/smm-architect/rendered.yaml
+++ b/infrastructure/kubernetes/helm/smm-architect/rendered.yaml
@@ -936,7 +936,7 @@ spec:
             runAsUser: 1001
             seccompProfile:
               type: RuntimeDefault
-          image: "docker.io/smm-architect/agents:latest"
+          image: "docker.io/smm-architect/agents:1.0.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -1036,7 +1036,7 @@ spec:
             runAsUser: 1001
             seccompProfile:
               type: RuntimeDefault
-          image: "docker.io/smm-architect/core:latest"
+          image: "docker.io/smm-architect/core:1.0.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -1136,7 +1136,7 @@ spec:
             runAsUser: 1001
             seccompProfile:
               type: RuntimeDefault
-          image: "docker.io/smm-architect/frontend:latest"
+          image: "docker.io/smm-architect/frontend:1.0.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -1236,7 +1236,7 @@ spec:
             runAsUser: 1001
             seccompProfile:
               type: RuntimeDefault
-          image: "docker.io/smm-architect/model-router:latest"
+          image: "docker.io/smm-architect/model-router:1.0.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -1336,7 +1336,7 @@ spec:
             runAsUser: 1001
             seccompProfile:
               type: RuntimeDefault
-          image: "docker.io/smm-architect/publisher:latest"
+          image: "docker.io/smm-architect/publisher:1.0.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -1436,7 +1436,7 @@ spec:
             runAsUser: 1001
             seccompProfile:
               type: RuntimeDefault
-          image: "docker.io/smm-architect/toolhub:latest"
+          image: "docker.io/smm-architect/toolhub:1.0.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/security/audit/audit-configuration.yaml
+++ b/security/audit/audit-configuration.yaml
@@ -381,7 +381,7 @@ spec:
         spec:
           containers:
           - name: integrity-checker
-            image: smm-architect/audit-tools:latest
+            image: smm-architect/audit-tools:1.0.0
             command:
             - /bin/bash
             - -c

--- a/services/model-router/README.md
+++ b/services/model-router/README.md
@@ -565,7 +565,7 @@ spec:
     spec:
       containers:
       - name: model-router
-        image: smm-architect/model-router:latest
+        image: smm-architect/model-router:1.0.0
         ports:
         - containerPort: 3003
         env:

--- a/tests/security/security-tests.test.ts
+++ b/tests/security/security-tests.test.ts
@@ -513,7 +513,7 @@ describe('End-to-End Security Testing', () => {
 
     it('should validate container security', async () => {
       const containerScanResults = await vulnerabilityScanner.scanContainer({
-        imageName: 'smm-architect:latest',
+        imageName: 'smm-architect:1.0.0',
         scanLayers: true,
         checkBaseImage: true,
         validateSecurityPolicies: true

--- a/tools/cli/smm-cli.js
+++ b/tools/cli/smm-cli.js
@@ -12,13 +12,15 @@ import { execSync, spawn } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 
+const VERSION = '1.0.0';
+
 const program = new Command();
 
 // CLI Configuration
 program
   .name('smm-cli')
   .description('SMM Architect Unified CLI Tool')
-  .version('1.0.0');
+  .version(VERSION);
 
 // Development Commands
 const devCommand = program
@@ -93,7 +95,7 @@ buildCommand
   .action(async (options) => {
     if (options.service) {
       console.log(`🐳 Building Docker image for ${options.service}...`);
-      execSync(`docker build -f services/${options.service}/Dockerfile -t smm-architect/${options.service}:latest .`, { stdio: 'inherit' });
+      execSync(`docker build -f services/${options.service}/Dockerfile -t smm-architect/${options.service}:${VERSION} .`, { stdio: 'inherit' });
     } else {
       console.log('🐳 Building all Docker images...');
       execSync('docker-compose build', { stdio: 'inherit' });

--- a/tools/scripts/production-readiness-validation.sh
+++ b/tools/scripts/production-readiness-validation.sh
@@ -310,7 +310,7 @@ run_security_scan() {
     
     # Container image vulnerabilities
     if command -v trivy >/dev/null 2>&1; then
-        run_check_with_output "Container vulnerability scan" "trivy image --severity HIGH,CRITICAL --quiet --format json nginx:latest | jq '.Results | length'"
+        run_check_with_output "Container vulnerability scan" "trivy image --severity HIGH,CRITICAL --quiet --format json nginx:1.25.3 | jq '.Results | length'"
     else
         log_warning "Trivy not available - manual container scanning required"
         ((WARNING_CHECKS++))


### PR DESCRIPTION
## Summary
- replace `:latest` image tags with explicit versions in docker-compose and kubernetes manifests
- pin internal images and tools to `1.0.0` and third-party services to stable releases
- update CLI, tests and docs to use versioned images

## Testing
- `make test` *(fails: turbo: not found)*
- `make test-security` *(fails: RLS violations reported)*

------
https://chatgpt.com/codex/tasks/task_e_68b986d0a818832baff9d7959542dc8b