### PR TITLE
refactor: use env vars for service passwords

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,11 @@ SENTRY_ENABLED=true
 NODE_ENV=development
 PORT=3000
 
+# Database and Cache Credentials
+DB_PASSWORD=change_me
+REDIS_PASSWORD=change_me
+GRAFANA_ADMIN_PASSWORD=change_me
+
 # Optional: Sentry Release Tracking
 npm_package_version=1.0.0
 APP_VERSION=1.0.0

--- a/README.md
+++ b/README.md
@@ -412,6 +412,9 @@ cd services/toolhub && pnpm test:benchmark
 | `VAULT_ADDR` | Vault server address | `http://localhost:8200` |
 | `VAULT_TOKEN` | Vault authentication token | - |
 | `DATABASE_URL` | PostgreSQL connection string | - |
+| `DB_PASSWORD` | Database password for PostgreSQL services | - |
+| `REDIS_PASSWORD` | Redis authentication password | - |
+| `GRAFANA_ADMIN_PASSWORD` | Grafana admin password | - |
 | `PINECONE_API_KEY` | Vector database API key | - |
 
 ### Workspace Configuration

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     environment:
       POSTGRES_DB: smm_architect
       POSTGRES_USER: smm_user
-      POSTGRES_PASSWORD: smm_password
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
       POSTGRES_MULTIPLE_DATABASES: smm_architect,smm_test
     ports:
       - "5432:5432"
@@ -26,12 +26,13 @@ services:
   redis:
     image: redis:7-alpine
     container_name: smm-redis
+    command: ["redis-server", "--requirepass", "${REDIS_PASSWORD}"]
     ports:
       - "6379:6379"
     volumes:
       - redis_data:/data
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD}", "ping"]
       interval: 30s
       timeout: 3s
       retries: 3
@@ -49,8 +50,8 @@ services:
     environment:
       - NODE_ENV=development
       - PORT=4000
-      - DATABASE_URL=postgresql://smm_user:smm_password@postgres:5432/smm_architect
-      - REDIS_URL=redis://redis:6379
+      - DATABASE_URL=postgresql://smm_user:${DB_PASSWORD}@postgres:5432/smm_architect
+      - REDIS_URL=redis://:${REDIS_PASSWORD}@redis:6379
       - VAULT_URL=http://vault:8200
       - SENTRY_DSN=${SENTRY_DSN}
     depends_on:
@@ -75,8 +76,8 @@ services:
     environment:
       - NODE_ENV=development
       - PORT=3001
-      - DATABASE_URL=postgresql://smm_user:smm_password@postgres:5432/smm_architect
-      - REDIS_URL=redis://redis:6379
+      - DATABASE_URL=postgresql://smm_user:${DB_PASSWORD}@postgres:5432/smm_architect
+      - REDIS_URL=redis://:${REDIS_PASSWORD}@redis:6379
       - VAULT_URL=http://vault:8200
       - SENTRY_DSN=${SENTRY_DSN}
       - OPENAI_API_KEY=${OPENAI_API_KEY}
@@ -155,7 +156,7 @@ services:
     ports:
       - "3001:3000"
     environment:
-      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD}
     volumes:
       - grafana_data:/var/lib/grafana
       - ./monitoring/dashboards:/etc/grafana/provisioning/dashboards
@@ -180,7 +181,7 @@ services:
     environment:
       POSTGRES_DB: smm_test
       POSTGRES_USER: smm_test
-      POSTGRES_PASSWORD: smm_test
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
     ports:
       - "5433:5432"
     volumes:


### PR DESCRIPTION
## Summary
- replace hard-coded passwords in docker-compose with env vars
- document DB and Redis credentials in README and .env example

## Testing
- `make test` *(fails: turbo not found)*
- `make test-security` *(fails: RLS violations)*

------
https://chatgpt.com/codex/tasks/task_e_68b986cf00d0832b8259d1cea32074d8
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Replaced hard-coded service passwords in docker-compose with environment variables for Postgres, Redis, and Grafana. Improves security and makes local and CI configuration easier.

- **Refactors**
  - Use DB_PASSWORD for Postgres containers and app DATABASE_URL.
  - Enable Redis auth; use REDIS_PASSWORD in command, healthcheck, and REDIS_URL.
  - Use GRAFANA_ADMIN_PASSWORD for Grafana admin.
  - Document new vars in README and .env.example.

- **Migration**
  - Copy .env.example and set DB_PASSWORD, REDIS_PASSWORD, and GRAFANA_ADMIN_PASSWORD (defaults are change_me).
  - Restart the stack: docker compose down && docker compose up -d.
  - If using redis-cli locally, pass -a "$REDIS_PASSWORD".

<!-- End of auto-generated description by cubic. -->

