### PR TITLE
feat: auto-detect project root in cleanup script

### DIFF
--- a/cleanup.sh
+++ b/cleanup.sh
@@ -3,6 +3,9 @@
 # SMM Architect Enterprise Project Cleanup Script
 # Tailored for: Turborepo + pnpm + Encore.ts + Next.js + Storybook + Playwright + Artillery
 # Optimized for monorepo architecture with microservices
+#
+# Usage: ./cleanup.sh [project_root]
+# If project_root is not provided, the script auto-detects the repository root
 
 set -euo pipefail
 
@@ -17,7 +20,11 @@ BOLD='\033[1m'
 NC='\033[0m' # No Color
 
 # Project configuration
-PROJECT_ROOT="/Users/ivan/smm-architect"
+if [ $# -gt 0 ]; then
+    PROJECT_ROOT="$1"
+else
+    PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+fi
 PROJECT_NAME="SMM Architect"
 MONOREPO_WORKSPACES=("apps" "packages" "services" "tools")
 TURBO_CACHE_DIR=".turbo"


### PR DESCRIPTION
## Summary
- allow cleanup.sh to accept project root argument or auto-detect via git
- document new optional project_root parameter

## Testing
- `make test` *(fails: turbo not found)*
- `make test-security` *(fails: RLS policy requirements missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b986cc9ce0832b93e3eed151e4754b
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Make cleanup.sh portable by accepting an optional project_root argument and auto-detecting the repo root via git when not provided. Removes the hard-coded path and updates the inline usage docs.

<!-- End of auto-generated description by cubic. -->

