### PR TITLE
refactor: await Sentry flush instead of manual exit

### DIFF
--- a/ai-span-tracking-test.js
+++ b/ai-span-tracking-test.js
@@ -178,15 +178,13 @@ async function runAllTests() {
   
   // Flush Sentry events
   const Sentry = require('@sentry/node');
-  await Sentry.close(2000);
-  
-  process.exit(0);
+  await Sentry.flush(2000);
 }
 
 // Handle errors
 process.on('unhandledRejection', (error) => {
   console.error('❌ Unhandled promise rejection:', error);
-  process.exit(1);
+  process.exitCode = 1;
 });
 
 // Run the tests


### PR DESCRIPTION
## Summary
- await Sentry.flush before finishing span tracking tests
- rely on process exit code without manual `process.exit`

## Testing
- `node ai-span-tracking-test.js`
- `npm test` *(fails: tsup: not found; encore: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b986c973cc832ba0c8214a97438c40
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Await Sentry.flush in ai-span-tracking-test.js to ensure events are sent before the process ends. Replace manual process.exit calls with process.exitCode to avoid abrupt termination and play nicer with test runners.

<!-- End of auto-generated description by cubic. -->

