### PR TITLE
chore: use pnpm scripts in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,18 +24,18 @@ help: ## Show this help message
 
 install: ## Install all dependencies
 	@echo "$(YELLOW)Installing dependencies...$(NC)"
-	npm install
+	pnpm install
 	@echo "$(GREEN)Dependencies installed successfully$(NC)"
 
 build: ## Build all services
 	@echo "$(YELLOW)Building all services...$(NC)"
-	cd services/smm-architect && npm run build
-	cd apps/frontend && npm run build
+	cd services/smm-architect && pnpm build
+	cd apps/frontend && pnpm build
 	@echo "$(GREEN)Build completed successfully$(NC)"
 
 test: ## Run all tests
 	@echo "$(YELLOW)Running tests...$(NC)"
-	npm test
+	pnpm test
 	@echo "$(GREEN)Tests completed$(NC)"
 
 test-security: ## Run security tests including tenant isolation
@@ -43,7 +43,7 @@ test-security: ## Run security tests including tenant isolation
 	@echo "🔍 Validating RLS policies in migrations..."
 	node tools/migration-rls-linter.js services/smm-architect/migrations/
 	@echo "🔴 Running evil tenant security tests..."
-	npm run test:security
+	pnpm test:security
 	@echo "$(GREEN)Security tests completed$(NC)"
 
 clean: ## Clean build artifacts and temporary files
@@ -127,14 +127,14 @@ docker-sbom: ## Generate SBOM for Docker images
 # Development Workflow Targets
 dev-setup: install ## Complete development environment setup
 	@echo "$(YELLOW)Setting up development environment...$(NC)"
-	npm install
+	pnpm install
 	chmod +x tools/scripts/*.sh
 	@echo "$(GREEN)Development environment setup completed$(NC)"
 
 dev-check: test test-security sbom ## Run all development checks (tests, security, SBOM)
 	@echo "$(YELLOW)Running complete development checks...$(NC)"
-	npm test
-	npm run test:security
+	pnpm test
+	pnpm test:security
 	$(MAKE) sbom-quick
 	@echo "$(GREEN)All development checks passed$(NC)"
 


### PR DESCRIPTION
## Summary
- replace npm script invocations with pnpm in Makefile

## Testing
- `pnpm install` *(fails: ModuleNotFoundError: No module named 'distutils')*
- `make test` *(fails: turbo: not found)*
- `make test-security` *(fails: RLS violations reported)*

------
https://chatgpt.com/codex/tasks/task_e_68b986c7b1d8832b84e4ab0c7e5c9818
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Replaced all npm invocations in the Makefile with pnpm to standardize package management and speed up installs across common tasks.

- **Refactors**
  - Updated Makefile targets (install, build, test, test-security, dev-setup, dev-check) to use pnpm commands.

- **Migration**
  - Ensure pnpm is available (e.g., run: corepack enable).
  - Run pnpm install before make targets.
  - Verify required CLIs (e.g., turbo) are declared as devDependencies so pnpm resolves them.

<!-- End of auto-generated description by cubic. -->

