### PR TITLE
feat: use randomUUID for SIEM audit events

### DIFF
--- a/services/shared/middleware/auth-middleware.ts
+++ b/services/shared/middleware/auth-middleware.ts
@@ -9,6 +9,7 @@ import { Request, Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
 import winston from 'winston';
 import axios from 'axios';
+import { randomUUID } from 'crypto';
 import { withTenantContext, requireValidTenantContext } from '../database/client';
 import { jwtTokenCache, CachedTokenPayload } from '../jwt-cache';
 import { securityMetrics } from '../security/security-metrics';
@@ -48,7 +49,7 @@ async function sendToSIEM(auditEvent: {
   try {
     const payload = {
       timestamp: auditEvent.timestamp.toISOString(),
-      eventId: `auth_${Date.now()}_${Math.random().toString(36).substring(2)}`,
+      eventId: `auth_${randomUUID()}`,
       source: 'smm-architect-auth',
       ...auditEvent
     };


### PR DESCRIPTION
## Summary
- use crypto.randomUUID to generate SIEM event IDs in auth middleware

## Testing
- `make test` *(fails: tsup not found)*
- `make test-security` *(fails: missing RLS policies)*

------
https://chatgpt.com/codex/tasks/task_e_68b980d96e98832ba8ffa6d2a2a02281
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Use crypto.randomUUID to generate SIEM audit event IDs in the auth middleware. This improves ID uniqueness and consistency, with no payload changes beyond the eventId value format.

<!-- End of auto-generated description by cubic. -->

