### PR TITLE
chore: harden frontend CSP

### DIFF
--- a/apps/frontend/next.config.i18n.js
+++ b/apps/frontend/next.config.i18n.js
@@ -62,8 +62,9 @@ const nextConfig = {
             key: 'Content-Security-Policy',
             value: [
               "default-src 'self'",
-              "script-src 'self' 'unsafe-eval' 'unsafe-inline'",
-              "style-src 'self' 'unsafe-inline'",
+              // Use nonces or hashes instead of unsafe directives
+              "script-src 'self' 'nonce-__CSP_NONCE__'",
+              "style-src 'self' 'nonce-__CSP_NONCE__'",
               "img-src 'self' data: https:",
               "font-src 'self'",
               "connect-src 'self' https:",
@@ -149,5 +150,4 @@ const nextConfig = {
     ]
   },
 }
-
 module.exports = nextConfig


### PR DESCRIPTION
## Summary
- remove unsafe CSP directives in frontend i18n config
- add nonce placeholder for scripts and styles

## Testing
- `make test` *(fails: npm not found)*
- `make test-security` *(fails: node not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b980d8ebc4832b8713bcf78e36af0d
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Hardened the frontend Content Security Policy by removing 'unsafe-inline' and 'unsafe-eval' and switching script/style directives to nonce-based. This reduces XSS risk and enforces stricter execution rules.

- **Migration**
  - Generate a per-request CSP nonce and replace __CSP_NONCE__ in the header.
  - Add nonce attributes to all inline script/style tags; avoid eval.
  - Ensure third‑party snippets support nonces or load from allowed origins.

<!-- End of auto-generated description by cubic. -->

