### PR TITLE
feat(toolhub): enforce API keys in production

### DIFF
--- a/services/toolhub/src/services/vector-service.ts
+++ b/services/toolhub/src/services/vector-service.ts
@@ -56,7 +56,12 @@ export class VectorService {
     this.pineconeApiKey = process.env.PINECONE_API_KEY || '';
     this.pineconeEnvironment = process.env.PINECONE_ENVIRONMENT || 'us-east1-gcp';
     this.pineconeIndex = process.env.PINECONE_INDEX || 'smm-architect';
-    
+
+    const isProduction = process.env.NODE_ENV === 'production';
+    if (isProduction && (!this.openaiApiKey || !this.pineconeApiKey)) {
+      throw new Error('Vector service: Missing API keys in production');
+    }
+
     if (!this.openaiApiKey || !this.pineconeApiKey) {
       console.warn('Vector service: Missing API keys, using mock mode');
     }


### PR DESCRIPTION
## Summary
- require OPENAI_API_KEY and PINECONE_API_KEY when NODE_ENV is production

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: run-s not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b980d45d84832bab303bc0740ffaaf
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Enforce API keys in production for the vector service to prevent running in mock mode. When NODE_ENV=production, the service throws if OPENAI_API_KEY or PINECONE_API_KEY is missing; non-prod still logs a warning.

<!-- End of auto-generated description by cubic. -->

