### PR TITLE
feat: secure publisher service

### DIFF
--- a/services/publisher/src/middleware/error-handler.ts
+++ b/services/publisher/src/middleware/error-handler.ts
@@ -1,5 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 import * as Sentry from '@sentry/node';
+import crypto from 'crypto';
 
 export class ApiError extends Error {
   public statusCode: number;
@@ -296,7 +297,7 @@ export function formatValidationError(errors: any[]): any {
  * Generate unique request ID
  */
 function generateRequestId(): string {
-  return `req_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+  return `req_${crypto.randomUUID()}`;
 }
 
 /**


### PR DESCRIPTION
## Summary
- use nonce-based CSP to remove unsafe-inline style usage
- generate request IDs with crypto.randomUUID
- back express-rate-limit with Redis store

## Testing
- `make test` (fails: npm not found)
- `make test-security` (fails: node not found)


------
https://chatgpt.com/codex/tasks/task_e_68b980d2c72c832b98bfb188daef78a7
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Hardened the publisher service by enforcing a nonce-based CSP, moving rate limiting to Redis, and generating cryptographically strong request IDs. This reduces XSS risk and keeps rate limits consistent across instances.

- **New Features**
  - Enforced nonce-based CSP for styles; removed unsafe-inline.
  - Backed express-rate-limit with a Redis store for shared limits.
  - Generated request IDs with crypto.randomUUID and set X-Request-ID header.

<!-- End of auto-generated description by cubic. -->

