### PR TITLE
feat: strengthen session id generation

### DIFF
--- a/apps/frontend/src/lib/monitoring.ts
+++ b/apps/frontend/src/lib/monitoring.ts
@@ -221,7 +221,16 @@ class FrontendMetrics implements MetricsCollector {
   private generateSessionId(): string {
     let sessionId = sessionStorage.getItem('session_id')
     if (!sessionId) {
-      sessionId = `session-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`
+      const cryptoObj = globalThis.crypto as Crypto | undefined
+      if (cryptoObj?.randomUUID) {
+        sessionId = `session-${cryptoObj.randomUUID()}`
+      } else if (cryptoObj?.getRandomValues) {
+        const array = new Uint8Array(16)
+        cryptoObj.getRandomValues(array)
+        sessionId = `session-${Array.from(array, byte => byte.toString(16).padStart(2, '0')).join('')}`
+      } else {
+        throw new Error('Secure random number generation is not supported')
+      }
       sessionStorage.setItem('session_id', sessionId)
     }
     return sessionId

--- a/apps/frontend/src/lib/monitoring/analytics.ts
+++ b/apps/frontend/src/lib/monitoring/analytics.ts
@@ -516,7 +516,16 @@ export class AnalyticsTracker {
   }
   
   private generateSessionId(): string {
-    return `session_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`
+    const cryptoObj = globalThis.crypto as Crypto | undefined
+    if (cryptoObj?.randomUUID) {
+      return `session_${cryptoObj.randomUUID()}`
+    }
+    if (cryptoObj?.getRandomValues) {
+      const array = new Uint8Array(16)
+      cryptoObj.getRandomValues(array)
+      return `session_${Array.from(array, b => b.toString(16).padStart(2, '0')).join('')}`
+    }
+    throw new Error('Secure random number generation is not supported')
   }
   
   private generatePageViewId(): string {

--- a/apps/frontend/src/lib/monitoring/error-tracker.ts
+++ b/apps/frontend/src/lib/monitoring/error-tracker.ts
@@ -499,7 +499,16 @@ export class ErrorTracker {
   }
   
   private generateSessionId(): string {
-    return `session_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`
+    const cryptoObj = globalThis.crypto as Crypto | undefined
+    if (cryptoObj?.randomUUID) {
+      return `session_${cryptoObj.randomUUID()}`
+    }
+    if (cryptoObj?.getRandomValues) {
+      const array = new Uint8Array(16)
+      cryptoObj.getRandomValues(array)
+      return `session_${Array.from(array, b => b.toString(16).padStart(2, '0')).join('')}`
+    }
+    throw new Error('Secure random number generation is not supported')
   }
   
   public destroy() {

--- a/apps/frontend/src/lib/monitoring/performance.ts
+++ b/apps/frontend/src/lib/monitoring/performance.ts
@@ -397,7 +397,16 @@ export class PerformanceMonitor {
   }
   
   private generateSessionId(): string {
-    return `session_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`
+    const cryptoObj = globalThis.crypto as Crypto | undefined
+    if (cryptoObj?.randomUUID) {
+      return `session_${cryptoObj.randomUUID()}`
+    }
+    if (cryptoObj?.getRandomValues) {
+      const array = new Uint8Array(16)
+      cryptoObj.getRandomValues(array)
+      return `session_${Array.from(array, b => b.toString(16).padStart(2, '0')).join('')}`
+    }
+    throw new Error('Secure random number generation is not supported')
   }
   
   public destroy() {

--- a/apps/frontend/src/lib/security/session-management.ts
+++ b/apps/frontend/src/lib/security/session-management.ts
@@ -150,16 +150,25 @@ if (typeof setInterval !== 'undefined') {
  * Generate cryptographic session ID
  */
 export const generateSessionId = (): string => {
-  if (typeof crypto !== 'undefined' && crypto.getRandomValues) {
+  const globalCrypto = globalThis.crypto as (Crypto & { randomUUID?: () => string }) | undefined
+
+  if (globalCrypto?.randomUUID) {
+    return globalCrypto.randomUUID().replace(/-/g, '')
+  }
+
+  if (globalCrypto?.getRandomValues) {
     const array = new Uint8Array(32)
-    crypto.getRandomValues(array)
+    globalCrypto.getRandomValues(array)
     return Array.from(array, byte => byte.toString(16).padStart(2, '0')).join('')
   }
-  
-  // Fallback for environments without crypto
-  return Math.random().toString(36).substring(2) + 
-         Math.random().toString(36).substring(2) +
-         Date.now().toString(36)
+
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const nodeCrypto = require('crypto') as { randomUUID?: () => string; randomBytes: (size: number) => Buffer }
+    return nodeCrypto.randomUUID ? nodeCrypto.randomUUID().replace(/-/g, '') : nodeCrypto.randomBytes(32).toString('hex')
+  } catch {
+    throw new Error('Secure random number generation is not supported in this environment')
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- replace fallback Math.random logic with crypto-based generation in session management
- generate monitoring session identifiers using `crypto.randomUUID`

## Testing
- `make test` *(fails: turbo: not found)*
- `make test-security` *(fails: RLS policy violations)*

------
https://chatgpt.com/codex/tasks/task_e_68b97d69513c832b9ff9872813a4cdcd