### PR TITLE
feat: add redis session store

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -40,6 +40,7 @@
     "date-fns": "^2.30.0",
     "dompurify": "^3.0.5",
     "jose": "^5.2.0",
+    "ioredis": "^5.3.2",
     "lucide-react": "^0.263.1",
     "next": "^14.0.0",
     "react": "^18.2.0",

--- a/apps/frontend/src/lib/security/README.md
+++ b/apps/frontend/src/lib/security/README.md
@@ -15,7 +15,7 @@ This comprehensive security implementation provides multiple layers of protectio
 ### 🔐 Session Management
 - **JWT-based Sessions**: Cryptographically signed tokens
 - **Secure Cookies**: HttpOnly, Secure, SameSite protection
-- **Session Store**: In-memory session tracking with cleanup
+- **Session Store**: Redis-backed session tracking with optional in-memory fallback
 - **Auto-renewal**: Automatic token refresh before expiry
 - **Multi-session Control**: Limit concurrent sessions per user
 - **Role-based Access**: RBAC and permission-based controls
@@ -56,7 +56,8 @@ The security implementation uses these dependencies (already included in package
 {
   "dependencies": {
     "jose": "^5.1.3",
-    "isomorphic-dompurify": "^2.6.0"
+    "isomorphic-dompurify": "^2.6.0",
+    "ioredis": "^5.3.2"
   }
 }
 ```
@@ -70,6 +71,7 @@ CSRF_SECRET=your-csrf-secret-key
 CSP_REPORT_URI=https://your-domain.com/api/security/csp-report
 RATE_LIMIT_ENABLED=true
 SECURITY_DEBUG_MODE=false
+SESSION_STORE_URL=redis://localhost:6379
 ```
 
 ### 3. Middleware Configuration


### PR DESCRIPTION
## Summary
- replace in-memory session store with pluggable Redis-backed implementation
- add session store connection options and Redis dependency
- document Redis session configuration for frontend security

## Testing
- `pnpm test` *(fails: turbo: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b97d684d2c832b8ad4fac693b68293
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Replaced the in-memory session store with a pluggable Redis-backed implementation for scalable, persistent session tracking with an in-memory fallback.

- **New Features**
  - Added SessionStore interface with RedisSessionStore and InMemorySessionStore; auto-selects Redis when SESSION_STORE_URL is set.
  - Extended SessionConfig with storeType and storeUrl; session operations are async; per-user maxSessions enforced in the store.
  - Redis uses TTL for session keys and a sorted set per user to track and prune oldest sessions.

- **Migration**
  - Optional: set SESSION_STORE_URL=redis://host:6379 to enable Redis-backed sessions.
  - No breaking changes; defaults to in-memory if not configured.

<!-- End of auto-generated description by cubic. -->

