### PR TITLE
fix: enforce session secret configuration

### DIFF
--- a/apps/frontend/src/lib/security/session-management.ts
+++ b/apps/frontend/src/lib/security/session-management.ts
@@ -34,8 +34,18 @@ export interface SessionConfig {
   requireTwoFactor: boolean
 }
 
+const getSessionSecret = (): string => {
+  const secret = process.env.SESSION_SECRET
+
+  if (!secret) {
+    throw new Error('SESSION_SECRET environment variable is required')
+  }
+
+  return secret
+}
+
 const DEFAULT_SESSION_CONFIG: SessionConfig = {
-  secret: process.env.SESSION_SECRET || 'default-secret-change-in-production',
+  secret: getSessionSecret(),
   cookieName: '__session',
   maxAge: 24 * 60 * 60, // 24 hours
   secure: process.env.NODE_ENV === 'production',


### PR DESCRIPTION
## Summary
- enforce presence of `SESSION_SECRET` by removing insecure fallback
- add explicit error when `SESSION_SECRET` environment variable is missing

## Testing
- `SESSION_SECRET=testsecret pnpm test` *(fails: turbo not found)*
- `pnpm install` *(fails: ModuleNotFoundError: No module named 'distutils')*

------
https://chatgpt.com/codex/tasks/task_e_68b97d678334832b9253f35b0f6024f7
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Enforces a required SESSION_SECRET by removing the insecure fallback and failing fast with a clear error if it’s missing. This hardens session management and prevents accidental insecure configs.

- **Migration**
  - Set SESSION_SECRET in all environments (local, CI, staging, prod). Startup will fail if unset.

<!-- End of auto-generated description by cubic. -->

