### PR TITLE
Restrict sanitizeUrl default to HTTP/HTTPS

### DIFF
--- a/apps/frontend/src/lib/security/input-sanitization.ts
+++ b/apps/frontend/src/lib/security/input-sanitization.ts
@@ -101,9 +101,10 @@ export const sanitizeText = (text: string, maxLength?: number): string => {
 }
 
 /**
- * Sanitize URL to prevent javascript: and data: schemes
+ * Sanitize URL to prevent javascript: and data: schemes.
+ * Only http/https are permitted by default; pass 'mailto:' explicitly when email links are needed.
  */
-export const sanitizeUrl = (url: string, allowedProtocols: string[] = ['http:', 'https:', 'mailto:']): string => {
+export const sanitizeUrl = (url: string, allowedProtocols: string[] = ['http:', 'https:']): string => {
   if (!url || typeof url !== 'string') {
     return ''
   }


### PR DESCRIPTION
## Summary
- limit `sanitizeUrl` to allow only http/https protocols by default
- require explicit inclusion of `mailto:` when email links are needed

## Testing
- `npm test` *(fails: turbo: not found)*
- `npm run test:security` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b97d6663dc832ba7d2c7f5a427f027