### PR TITLE
feat: add server-side validation for secure forms

### DIFF
--- a/apps/frontend/src/app/api/workspaces/[id]/route.ts
+++ b/apps/frontend/src/app/api/workspaces/[id]/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { validateWorkspaceData } from '../validation'
 
 // Mock workspace details with steps
 const mockWorkspaceDetails = {
@@ -89,29 +90,33 @@ export async function PATCH(
 ) {
   // Simulate network delay
   await new Promise(resolve => setTimeout(resolve, Math.random() * 500 + 200))
-  
+
   try {
     const workspaceId = params.id
     const workspace = mockWorkspaceDetails[workspaceId]
-    
+
     if (!workspace) {
       return NextResponse.json(
         { error: 'Workspace not found' },
         { status: 404 }
       )
     }
-    
+
     const body = await request.json()
-    
-    // Update workspace
+    const { data, errors } = validateWorkspaceData(body, { partial: true })
+
+    if (Object.keys(errors).length > 0) {
+      return NextResponse.json({ errors }, { status: 400 })
+    }
+
     const updatedWorkspace = {
       ...workspace,
-      ...body,
+      ...data,
       updatedAt: new Date().toISOString(),
     }
-    
+
     mockWorkspaceDetails[workspaceId] = updatedWorkspace
-    
+
     return NextResponse.json(updatedWorkspace)
   } catch (error) {
     return NextResponse.json(

--- a/apps/frontend/src/app/api/workspaces/validation.ts
+++ b/apps/frontend/src/app/api/workspaces/validation.ts
@@ -1,0 +1,44 @@
+import { sanitizeFormData, sanitizeText, sanitizeNumber } from '@/lib/security/input-sanitization'
+
+export interface WorkspaceInput {
+  name: string
+  description: string
+  budget?: {
+    used: number
+    total: number
+    currency: string
+  }
+  channels?: string[]
+}
+
+interface ValidationOptions {
+  partial?: boolean
+}
+
+export function validateWorkspaceData(
+  input: any,
+  options: ValidationOptions = {}
+): { data: WorkspaceInput; errors: Record<string, string> } {
+  const { partial = false } = options
+
+  const { data, errors } = sanitizeFormData(input, {
+    name: { type: 'text', required: !partial, maxLength: 100 },
+    description: { type: 'text', required: !partial, maxLength: 500 }
+  })
+
+  if (input?.budget) {
+    data.budget = {
+      used: sanitizeNumber(input.budget.used, { min: 0 }) ?? 0,
+      total: sanitizeNumber(input.budget.total, { min: 0 }) ?? 0,
+      currency: sanitizeText(input.budget.currency, 3)
+    }
+  }
+
+  if (Array.isArray(input?.channels)) {
+    data.channels = input.channels
+      .map((ch: string) => sanitizeText(ch, 50))
+      .filter(ch => ch.length > 0)
+  }
+
+  return { data: data as WorkspaceInput, errors }
+}

--- a/apps/frontend/src/hooks/use-security.ts
+++ b/apps/frontend/src/hooks/use-security.ts
@@ -31,6 +31,10 @@ export const useSanitization = () => {
 
 /**
  * Hook for secure form handling
+ *
+ * Server-side validation mirrors these rules using `sanitizeFormData` and
+ * related utilities (see `app/api/workspaces/validation.ts`) to prevent
+ * client-side bypass.
  */
 export const useSecureForm = <T extends Record<string, any>>(
   initialValues: T,

--- a/apps/frontend/src/lib/security/README.md
+++ b/apps/frontend/src/lib/security/README.md
@@ -245,6 +245,26 @@ export const POST = requirePermission(['users:create'], async (request, session)
 })
 ```
 
+### Server-side Form Validation
+
+Client-side hooks like `useSecureForm` sanitize and validate input, but all
+payloads are re-validated on the server using the same utilities to prevent
+tampering.
+
+```typescript
+// app/api/workspaces/route.ts
+import { validateWorkspaceData } from './validation'
+
+export async function POST(request: NextRequest) {
+  const body = await request.json()
+  const { data, errors } = validateWorkspaceData(body)
+  if (Object.keys(errors).length > 0) {
+    return NextResponse.json({ errors }, { status: 400 })
+  }
+  // use sanitized `data` to create the workspace
+}
+```
+
 ## Security Components
 
 ### Role-Based Access Control


### PR DESCRIPTION
## Summary
- add shared workspace input validator for API routes
- sanitize and validate workspace create/update requests
- document server-side validation in hooks and security guide

## Testing
- `make test` *(fails: @smm-architect/ui:build command exited with 1)*
- `make test-security` *(fails: RLS violations reported in migrations)*

------
https://chatgpt.com/codex/tasks/task_e_68b97d63f978832bb56a6381500b34a2
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds server-side validation and sanitization for workspace APIs to prevent malformed or tampered input. POST and PATCH now use shared rules aligned with the client, improving security and consistency.

- **New Features**
  - Added validateWorkspaceData (uses sanitizeFormData, sanitizeText, sanitizeNumber) with partial support for PATCH.
  - POST /api/workspaces validates input, returns { errors } with 400 on failure, and creates from sanitized data.
  - PATCH /api/workspaces/[id] validates partial payloads, merges sanitized fields, and returns 400 on invalid input.
  - Documented server-side validation in use-security hook and security guide.

<!-- End of auto-generated description by cubic. -->

