### PR TITLE
feat: use secure trace IDs

### DIFF
--- a/apps/frontend/src/lib/api.ts
+++ b/apps/frontend/src/lib/api.ts
@@ -121,7 +121,15 @@ class APIClient {
   }
 
   private generateTraceId(): string {
-    return `frontend-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+      return `frontend-${crypto.randomUUID()}`
+    }
+    const array = new Uint8Array(16)
+    if (typeof crypto !== 'undefined' && typeof crypto.getRandomValues === 'function') {
+      crypto.getRandomValues(array)
+      return `frontend-${Array.from(array, (b) => b.toString(16).padStart(2, '0')).join('')}`
+    }
+    throw new Error('Crypto API not available for trace ID generation')
   }
 }
 


### PR DESCRIPTION
## Summary
- use crypto APIs to generate trace IDs in frontend API client

## Testing
- `npx --yes turbo@latest test` *(fails: tsup not found)*
- `npm run test:security` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b97d631228832bae2ee80dd6fc2cbf