### PR TITLE
refactor: use robust sanitization utilities

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -39,6 +39,7 @@
     "clsx": "^2.0.0",
     "date-fns": "^2.30.0",
     "dompurify": "^3.0.5",
+    "sanitize-filename": "^1.6.3",
     "jose": "^5.2.0",
     "lucide-react": "^0.263.1",
     "next": "^14.0.0",
@@ -49,6 +50,7 @@
     "tailwind-merge": "^2.0.0",
     "tailwindcss-animate": "^1.0.7",
     "web-vitals": "^5.1.0",
+    "validator": "^13.11.0",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,6 +148,9 @@ importers:
       react-hook-form:
         specifier: ^7.48.2
         version: 7.62.0(react@18.3.1)
+      sanitize-filename:
+        specifier: ^1.6.3
+        version: 1.6.3
       swr:
         specifier: ^2.2.4
         version: 2.3.6(react@18.3.1)
@@ -157,6 +160,9 @@ importers:
       tailwindcss-animate:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@3.4.17)
+      validator:
+        specifier: ^13.11.0
+        version: 13.12.0
       web-vitals:
         specifier: ^5.1.0
         version: 5.1.0
@@ -22637,6 +22643,12 @@ packages:
   /safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  /sanitize-filename@1.6.3:
+    resolution: {integrity: sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==}
+    dependencies:
+      truncate-utf8-bytes: 1.0.2
+    dev: false
+
   /sass-loader@12.6.0(webpack@5.101.3):
     resolution: {integrity: sha512-oLTaH0YCtX4cfnJZxKSLAyglED0naiYfNG1iXfU5w1LNZ+ukoA5DtyDIN5zmKVZwYNJP4KRc5Y3hkWga+7tYfA==}
     engines: {node: '>= 12.13.0'}
@@ -23974,6 +23986,12 @@ packages:
     engines: {node: '>= 14.0.0'}
     dev: false
 
+  /truncate-utf8-bytes@1.0.2:
+    resolution: {integrity: sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==}
+    dependencies:
+      utf8-byte-length: 1.0.5
+    dev: false
+
   /ts-api-utils@1.4.3(typescript@5.9.2):
     resolution: {integrity: sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==}
     engines: {node: '>=16'}
@@ -24700,6 +24718,10 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     dependencies:
       react: 18.3.1
+    dev: false
+
+  /utf8-byte-length@1.0.5:
+    resolution: {integrity: sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==}
     dev: false
 
   /util-deprecate@1.0.2:


### PR DESCRIPTION
## Summary
- replace custom input, file, and URL sanitizers with validator and sanitize-filename
- declare validator and sanitize-filename dependencies

## Testing
- `make test` (fails: encore: not found)
- `make test-security` (fails: RLS policy violations)


------
https://chatgpt.com/codex/tasks/task_e_68b97d5daa90832b8aa2538836091ac7
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Replaced ad-hoc input, URL, and filename sanitizers with validator and sanitize-filename for stronger, consistent sanitization across the app.

- **Refactors**
  - sanitizeUserInput: use validator.escape + trim; keep 1000-char cap.
  - sanitizeFileName: use sanitize-filename; keep 255-char cap.
  - sanitizeUrl: validate with validator.isURL (require http/https); block localhost, private networks, .local, and IPs; return trimmed URL.

- **Dependencies**
  - Added validator and sanitize-filename to apps/frontend.

<!-- End of auto-generated description by cubic. -->

