### PR TITLE
feat(frontend): replace unsafe CSP directives with nonce

### DIFF
--- a/apps/frontend/src/lib/security.ts
+++ b/apps/frontend/src/lib/security.ts
@@ -1,17 +1,22 @@
 import DOMPurify from 'isomorphic-dompurify';
 
+export function generateNonce(length = 16): string {
+  const array = new Uint8Array(length);
+  globalThis.crypto.getRandomValues(array);
+  return Array.from(array, (byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
 // Content Security Policy configuration
-export const cspConfig = {
+export const cspConfig = (nonce: string) => ({
   'default-src': ["'self'"],
   'script-src': [
     "'self'",
-    "'unsafe-eval'", // Required for Next.js
-    "'unsafe-inline'", // Consider removing in production
+    `'nonce-${nonce}'`,
     'https://js.sentry-cdn.com',
   ],
   'style-src': [
     "'self'",
-    "'unsafe-inline'", // Required for Tailwind CSS
+    `'nonce-${nonce}'`,
     'https://fonts.googleapis.com',
   ],
   'img-src': [
@@ -35,10 +40,10 @@ export const cspConfig = {
   'form-action': ["'self'"],
   'object-src': ["'none'"],
   'frame-src': ["'none'"],
-};
+});
 
-export function generateCSP(): string {
-  return Object.entries(cspConfig)
+export function generateCSP(nonce: string): string {
+  return Object.entries(cspConfig(nonce))
     .map(([directive, sources]) => `${directive} ${sources.join(' ')}`)
     .join('; ');
 }


### PR DESCRIPTION
## Summary
- replace unsafe-inline and unsafe-eval directives with nonce-based policy
- add nonce generator and dynamic CSP creator

## Testing
- `make test` *(fails: @smm-architect/ui#build exited 1)*
- `make test-security` *(fails: RLS policy violations in migration linting)*

------
https://chatgpt.com/codex/tasks/task_e_68b97d5b2ef8832b82067fecd329fc94
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Replaced unsafe-inline and unsafe-eval in the frontend CSP with a per-request nonce to harden script and style execution. Added a nonce generator and updated CSP creation to use it.

- **Migration**
  - Generate a nonce per request: const nonce = generateNonce()
  - Set the CSP header with generateCSP(nonce)
  - Add nonce attributes to all inline <script> and <style> tags that must run

<!-- End of auto-generated description by cubic. -->

