### PR TITLE
feat: enforce tenant filter for workspace listing

### DIFF
--- a/services/smm-architect/src/main.ts
+++ b/services/smm-architect/src/main.ts
@@ -289,8 +289,12 @@ export const health = api(
  */
 export const listWorkspaces = api(
   { method: "GET", path: "/workspaces", auth: true },
-  async ({ tenantId }: { tenantId?: string }): Promise<{ workspaces: WorkspaceContract[] }> => {
+  async ({ tenantId }: { tenantId: string }): Promise<{ workspaces: WorkspaceContract[] }> => {
     try {
+      if (!tenantId) {
+        throw new Error("tenantId is required");
+      }
+
       log.info("Listing workspaces", { tenantId });
 
       const workspaces = await workspaceService.listWorkspaces(tenantId);
@@ -298,11 +302,11 @@ export const listWorkspaces = api(
       return { workspaces };
 
     } catch (error) {
-      log.error("Failed to list workspaces", { 
-        tenantId, 
-        error: error instanceof Error ? error.message : String(error) 
+      log.error("Failed to list workspaces", {
+        tenantId,
+        error: error instanceof Error ? error.message : String(error)
       });
-      captureException(error, { 
+      captureException(error, {
         endpoint: "listWorkspaces",
         tenantId: tenantId
       });

--- a/services/smm-architect/src/services/workspace-service.ts
+++ b/services/smm-architect/src/services/workspace-service.ts
@@ -89,10 +89,11 @@ export class WorkspaceService {
     return true;
   }
 
-  async listWorkspaces(tenantId?: string): Promise<WorkspaceContract[]> {
-    const query = tenantId 
-      ? await this.db.query("SELECT contract_data FROM workspaces WHERE tenant_id = ?", [tenantId])
-      : await this.db.query("SELECT contract_data FROM workspaces", []);
+  async listWorkspaces(tenantId: string): Promise<WorkspaceContract[]> {
+    const query = await this.db.query(
+      "SELECT contract_data FROM workspaces WHERE tenant_id = ?",
+      [tenantId]
+    );
     return query.map((row: any) => JSON.parse(row.contract_data));
   }
 


### PR DESCRIPTION
## Summary
- require tenantId when listing workspaces
- validate tenant presence at API layer

## Testing
- `node node_modules/turbo/bin/turbo test` *(fails: encore: not found)*
- `node ../../node_modules/jest/bin/jest.js`

------
https://chatgpt.com/codex/tasks/task_e_68b97d592ff8832b900408eafb5b6f7a