### PR TITLE
refactor: require JWT secret

### DIFF
--- a/services/smm-architect/src/middleware/auth.ts
+++ b/services/smm-architect/src/middleware/auth.ts
@@ -145,7 +145,7 @@ export function extractTenantId(req: Request): string | null {
  */
 export async function extractUserFromToken(token: string): Promise<AuthenticatedUser> {
   try {
-    const secretKey = process.env.JWT_SECRET || await getJWTSecret();
+    const secretKey = await getJWTSecret();
     const decoded = jwt.verify(token, secretKey) as any;
     
     // Validate required fields
@@ -173,7 +173,11 @@ export async function extractUserFromToken(token: string): Promise<Authenticated
  * Get JWT secret from environment
  */
 async function getJWTSecret(): Promise<string> {
-  return process.env.JWT_SECRET || 'fallback-secret-key';
+  const secret = process.env.JWT_SECRET;
+  if (!secret) {
+    throw new AuthenticationError('JWT_SECRET environment variable is not set');
+  }
+  return secret;
 }
 
 /**


### PR DESCRIPTION
## Summary
- remove fallback JWT secret in auth middleware
- throw explicit error when JWT_SECRET is missing

## Testing
- `make test` *(fails: turbo not found)*
- `make test-security` *(fails: Error 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b97d52b1e4832b89ace39670378a83
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Remove the fallback JWT secret and require JWT_SECRET for token verification. This hardens auth and fails fast with a clear error when the env var is missing.

- **Migration**
  - Set JWT_SECRET in all environments (dev, CI, staging, prod). Without it, authentication throws "JWT_SECRET environment variable is not set".

<!-- End of auto-generated description by cubic. -->

