### PR TITLE
feat: add Redis-backed rate limiter

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1075,6 +1075,9 @@ importers:
       encore.dev:
         specifier: ^1.0.0
         version: 1.49.1
+      ioredis:
+        specifier: ^5.3.2
+        version: 5.7.0
       node-vault:
         specifier: ^0.10.0
         version: 0.10.5

--- a/services/smm-architect/package.json
+++ b/services/smm-architect/package.json
@@ -10,40 +10,39 @@
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "test:performance": "jest --testPathPattern=performance --runInBand --detectOpenHandles",
-    "test:schema": "jest --testPathPattern=schema",
+    "test:schema": "jest --testNamePattern='schema' --timeout=60000",
     "benchmark": "npm run test:performance -- --verbose --outputFile=jest-performance-results.json",
     "test:contract": "jest --testNamePattern='pact' --runInBand",
     "test:model-evaluation": "jest --testNamePattern='model-evaluation' --timeout=300000",
     "test:drift-detection": "jest --testNamePattern='drift-detection' --timeout=120000",
     "test:security": "jest --testNamePattern='security' --timeout=180000",
-    "test:schema": "jest --testNamePattern='schema' --timeout=60000",
     "lint": "eslint src/**/*.ts",
     "lint:fix": "eslint src/**/*.ts --fix",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "encore.dev": "^1.0.0",
     "@google-cloud/kms": "^4.0.0",
-    "node-vault": "^0.10.0",
-    "ajv": "^8.12.0",
-    "winston": "^3.11.0",
-    "uuid": "^9.0.0",
-    "date-fns": "^2.30.0",
     "@sentry/node": "^7.99.0",
-    "@sentry/profiling-node": "^7.99.0"
+    "@sentry/profiling-node": "^7.99.0",
+    "ajv": "^8.12.0",
+    "date-fns": "^2.30.0",
+    "encore.dev": "^1.0.0",
+    "ioredis": "^5.3.2",
+    "node-vault": "^0.10.0",
+    "uuid": "^9.0.0",
+    "winston": "^3.11.0"
   },
   "devDependencies": {
+    "@types/jest": "^29.5.0",
     "@types/node": "^20.0.0",
     "@types/uuid": "^9.0.0",
-    "@types/jest": "^29.5.0",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
     "eslint": "^8.50.0",
     "jest": "^29.7.0",
+    "nock": "^13.3.3",
     "ts-jest": "^29.1.0",
-    "typescript": "^5.2.0",
-
-    "nock": "^13.3.3"
+    "typescript": "^5.2.0"
   },
   "keywords": [
     "smm",


### PR DESCRIPTION
## Summary
- use Redis for rate limiting with configurable connection options
- add ioredis dependency for shared store support

## Testing
- `pnpm test --filter smm-architect-service`
- `pnpm --filter smm-architect-service run test:security`


------
https://chatgpt.com/codex/tasks/task_e_68b97d4edef4832ba651f0f67afb85c3