### PR TITLE
refactor: async schema loading

### DIFF
--- a/services/smm-architect/src/main.ts
+++ b/services/smm-architect/src/main.ts
@@ -50,7 +50,17 @@ import {
 import { WorkspaceService } from "./services/workspace-service";
 import { SimulationService } from "./services/simulation-service";
 import { AuditService } from "./services/audit-service";
-import { validateWorkspaceContract } from "./utils/validation";
+import { validateWorkspaceContract, initValidation } from "./utils/validation";
+
+(async () => {
+  try {
+    await initValidation();
+  } catch (error) {
+    log.warn("Validation schema initialization failed", {
+      error: error instanceof Error ? error.message : String(error)
+    });
+  }
+})();
 
 // Database connection
 const db = new SQLDatabase("smm_architect", {


### PR DESCRIPTION
## Summary
- load workspace schema asynchronously at service startup
- ensure validation waits for schema initialization

## Testing
- `make test` *(fails: turbo not found)*
- `make test-security` *(fails: RLS violations reported)*

------
https://chatgpt.com/codex/tasks/task_e_68b97d4a652c832baae52bfbe80262eb