### PR TITLE
feat(auth): add bcrypt password hashing

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1069,6 +1069,9 @@ importers:
       ajv:
         specifier: ^8.12.0
         version: 8.17.1
+      bcryptjs:
+        specifier: ^2.4.3
+        version: 2.4.3
       date-fns:
         specifier: ^2.30.0
         version: 2.30.0

--- a/services/smm-architect/package.json
+++ b/services/smm-architect/package.json
@@ -10,40 +10,39 @@
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "test:performance": "jest --testPathPattern=performance --runInBand --detectOpenHandles",
-    "test:schema": "jest --testPathPattern=schema",
+    "test:schema": "jest --testNamePattern='schema' --timeout=60000",
     "benchmark": "npm run test:performance -- --verbose --outputFile=jest-performance-results.json",
     "test:contract": "jest --testNamePattern='pact' --runInBand",
     "test:model-evaluation": "jest --testNamePattern='model-evaluation' --timeout=300000",
     "test:drift-detection": "jest --testNamePattern='drift-detection' --timeout=120000",
     "test:security": "jest --testNamePattern='security' --timeout=180000",
-    "test:schema": "jest --testNamePattern='schema' --timeout=60000",
     "lint": "eslint src/**/*.ts",
     "lint:fix": "eslint src/**/*.ts --fix",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "encore.dev": "^1.0.0",
     "@google-cloud/kms": "^4.0.0",
-    "node-vault": "^0.10.0",
-    "ajv": "^8.12.0",
-    "winston": "^3.11.0",
-    "uuid": "^9.0.0",
-    "date-fns": "^2.30.0",
     "@sentry/node": "^7.99.0",
-    "@sentry/profiling-node": "^7.99.0"
+    "@sentry/profiling-node": "^7.99.0",
+    "ajv": "^8.12.0",
+    "bcryptjs": "^2.4.3",
+    "date-fns": "^2.30.0",
+    "encore.dev": "^1.0.0",
+    "node-vault": "^0.10.0",
+    "uuid": "^9.0.0",
+    "winston": "^3.11.0"
   },
   "devDependencies": {
+    "@types/jest": "^29.5.0",
     "@types/node": "^20.0.0",
     "@types/uuid": "^9.0.0",
-    "@types/jest": "^29.5.0",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
     "eslint": "^8.50.0",
     "jest": "^29.7.0",
+    "nock": "^13.3.3",
     "ts-jest": "^29.1.0",
-    "typescript": "^5.2.0",
-
-    "nock": "^13.3.3"
+    "typescript": "^5.2.0"
   },
   "keywords": [
     "smm",


### PR DESCRIPTION
## Summary
- use bcryptjs to hash and verify user passwords
- store hashed credentials during registration
- add bcryptjs dependency for smm-architect service

## Testing
- `npm test`
- `npm run test:security`


------
https://chatgpt.com/codex/tasks/task_e_68b97d46e704832b8480be92f4e8eb6f
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add bcrypt-based password hashing to the smm-architect auth service. Passwords are now hashed on registration and verified on login.

- **New Features**
  - Use bcryptjs (10 salt rounds) to hash and compare passwords.
  - Store passwordHash during registration; authenticate via bcrypt.compare.
  - Add in-memory user store with userExists and pass through generated userId.

- **Dependencies**
  - Add bcryptjs to smm-architect.

<!-- End of auto-generated description by cubic. -->

