### PR TITLE
feat: use jwt library for auth tokens

### DIFF
--- a/services/smm-architect/package.json
+++ b/services/smm-architect/package.json
@@ -30,12 +30,14 @@
     "uuid": "^9.0.0",
     "date-fns": "^2.30.0",
     "@sentry/node": "^7.99.0",
-    "@sentry/profiling-node": "^7.99.0"
+    "@sentry/profiling-node": "^7.99.0",
+    "jsonwebtoken": "^9.0.2"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
     "@types/uuid": "^9.0.0",
     "@types/jest": "^29.5.0",
+    "@types/jsonwebtoken": "^9.0.10",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
     "eslint": "^8.50.0",


### PR DESCRIPTION
## Summary
- replace custom token creation with jsonwebtoken
- sign refresh tokens with jsonwebtoken and verify on refresh
- declare jsonwebtoken dependencies for smm-architect service

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b97d44bf4c832bb3971f83710e5e7c
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Replaced custom HMAC tokens with signed JWTs for access and refresh tokens to improve security and enable proper verification. Added jsonwebtoken and type definitions to smm-architect.

- **Refactors**
  - Issue access tokens as HS256 JWTs (24h).
  - Issue refresh tokens as HS256 JWTs (30d) with type=refresh and version.
  - Verify refresh tokens with jwt.verify; reject wrong type or missing claims.
  - Apply consistent JWT secret validation and error logging.

- **Migration**
  - Set JWT_SECRET in the environment; it must pass validation.
  - Rotate existing refresh tokens; old tokens will not validate.
  - Optionally bump JWT_VERSION to invalidate older refresh tokens.

<!-- End of auto-generated description by cubic. -->

