### PR TITLE
chore: clarify NODE_ENV example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,8 @@ NEXT_PUBLIC_SENTRY_DSN=https://02a82d6e1d09e631f5ef7083e197c841@o450989937878630
 SENTRY_ENABLED=true
 
 # Application Configuration
-NODE_ENV=development
+# NODE_ENV sets the environment; acceptable values: development, production, test
+# NODE_ENV=development
 PORT=3000
 
 # Optional: Sentry Release Tracking


### PR DESCRIPTION
## Summary
- comment out NODE_ENV in env example and document supported values

## Testing
- `pre-commit run --files .env.example` *(fails: InvalidConfigError: Type tag 'typescript' is not recognized)*
- `make test` *(fails: command exited with error during build)*
- `make test-security` *(fails: make: *** [Makefile:44: test-security] Error 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b97d39df04832baecf3b17e76c767e