### PR TITLE
chore: scrub secrets from env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,10 @@
+# Environment variables for local development.
+# Retrieve all secrets from your organization's secret management service (e.g., Vault) rather than committing them here.
+
 # Sentry Configuration
-SENTRY_DSN=https://02a82d6e1d09e631f5ef7083e197c841@o4509899378786304.ingest.de.sentry.io/4509899558879312
-NEXT_PUBLIC_SENTRY_DSN=https://02a82d6e1d09e631f5ef7083e197c841@o4509899378786304.ingest.de.sentry.io/4509899558879312
+# Obtain Sentry DSN values from a secure secret manager (e.g., Vault) and never commit real tokens.
+SENTRY_DSN=
+NEXT_PUBLIC_SENTRY_DSN=
 SENTRY_ENABLED=true
 
 # Application Configuration


### PR DESCRIPTION
## Summary
- remove Sentry DSN tokens from `.env.example`
- advise developers to fetch secrets from secure storage

## Testing
- `make test` *(fails: turbo: not found)*
- `make test-security` *(fails: target does not exist or missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b97d382b5c832b86367a5f1686e99b
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed real Sentry DSN tokens from .env.example and added guidance to source secrets from a secret manager. This prevents committing plaintext tokens and reduces exposure risk.

- **Migration**
  - Get SENTRY_DSN and NEXT_PUBLIC_SENTRY_DSN from your secret manager and set them locally (do not commit).

<!-- End of auto-generated description by cubic. -->

