### PR TITLE
chore: sanitize docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,16 +7,14 @@ services:
     container_name: smm-postgres
     environment:
       POSTGRES_DB: smm_architect
-      POSTGRES_USER: smm_user
-      POSTGRES_PASSWORD: smm_password
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_MULTIPLE_DATABASES: smm_architect,smm_test
-    ports:
-      - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./services/smm-architect/migrations:/docker-entrypoint-initdb.d
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U smm_user -d smm_architect"]
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d smm_architect"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -26,8 +24,6 @@ services:
   redis:
     image: redis:7-alpine
     container_name: smm-redis
-    ports:
-      - "6379:6379"
     volumes:
       - redis_data:/data
     healthcheck:
@@ -44,14 +40,12 @@ services:
       context: .
       dockerfile: services/smm-architect/Dockerfile
     container_name: smm-architect-service
-    ports:
-      - "4000:4000"
     environment:
       - NODE_ENV=development
       - PORT=4000
-      - DATABASE_URL=postgresql://smm_user:smm_password@postgres:5432/smm_architect
-      - REDIS_URL=redis://redis:6379
-      - VAULT_URL=http://vault:8200
+      - DATABASE_URL=${DATABASE_URL}
+      - REDIS_URL=${REDIS_URL}
+      - VAULT_URL=${VAULT_URL}
       - SENTRY_DSN=${SENTRY_DSN}
     depends_on:
       postgres:
@@ -70,14 +64,12 @@ services:
       context: .
       dockerfile: services/toolhub/Dockerfile
     container_name: smm-toolhub
-    ports:
-      - "3001:3001"
     environment:
       - NODE_ENV=development
       - PORT=3001
-      - DATABASE_URL=postgresql://smm_user:smm_password@postgres:5432/smm_architect
-      - REDIS_URL=redis://redis:6379
-      - VAULT_URL=http://vault:8200
+      - DATABASE_URL=${DATABASE_URL}
+      - REDIS_URL=${REDIS_URL}
+      - VAULT_URL=${VAULT_URL}
       - SENTRY_DSN=${SENTRY_DSN}
       - OPENAI_API_KEY=${OPENAI_API_KEY}
     depends_on:
@@ -101,8 +93,8 @@ services:
       - "3000:3000"
     environment:
       - NODE_ENV=development
-      - NEXT_PUBLIC_API_URL=http://localhost:4000
-      - NEXT_PUBLIC_TOOLHUB_URL=http://localhost:3001
+      - NEXT_PUBLIC_API_URL=http://smm-architect-service:4000
+      - NEXT_PUBLIC_TOOLHUB_URL=http://smm-toolhub:3001
       - SENTRY_DSN=${SENTRY_DSN}
     depends_on:
       - smm-architect
@@ -117,10 +109,8 @@ services:
   vault:
     image: hashicorp/vault:1.15.2
     container_name: smm-vault
-    ports:
-      - "8200:8200"
     environment:
-      - VAULT_DEV_ROOT_TOKEN_ID=dev-root-token
+      - VAULT_DEV_ROOT_TOKEN_ID=${VAULT_DEV_ROOT_TOKEN_ID}
       - VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:8200
     cap_add:
       - IPC_LOCK
@@ -134,8 +124,6 @@ services:
   prometheus:
     image: prom/prometheus:latest
     container_name: smm-prometheus
-    ports:
-      - "9090:9090"
     volumes:
       - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
       - prometheus_data:/prometheus
@@ -152,10 +140,8 @@ services:
   grafana:
     image: grafana/grafana:latest
     container_name: smm-grafana
-    ports:
-      - "3001:3000"
     environment:
-      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_SECURITY_ADMIN_PASSWORD=${GF_SECURITY_ADMIN_PASSWORD}
     volumes:
       - grafana_data:/var/lib/grafana
       - ./monitoring/dashboards:/etc/grafana/provisioning/dashboards
@@ -167,9 +153,6 @@ services:
   mailhog:
     image: mailhog/mailhog:latest
     container_name: smm-mailhog
-    ports:
-      - "8025:8025"  # Web interface
-      - "1025:1025"  # SMTP
     networks:
       - smm-network
 
@@ -179,10 +162,8 @@ services:
     container_name: smm-postgres-test
     environment:
       POSTGRES_DB: smm_test
-      POSTGRES_USER: smm_test
-      POSTGRES_PASSWORD: smm_test
-    ports:
-      - "5433:5432"
+      POSTGRES_USER: ${POSTGRES_TEST_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_TEST_PASSWORD}
     volumes:
       - postgres_test_data:/var/lib/postgresql/data
     networks:


### PR DESCRIPTION
## Summary
- remove unnecessary port mappings from internal services
- replace placeholder credentials with environment variables
- point frontend to internal service URLs for API access

## Testing
- `pre-commit run --files docker-compose.yml` *(fails: Type tag 'typescript' is not recognized)*
- `make test` *(fails: turbo: not found)*
- `make test-security` *(fails: RLS violations in migrations)*

------
https://chatgpt.com/codex/tasks/task_e_68b97d33c80c832ba5f6f5b8d8c0563c
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Sanitized docker-compose by removing exposed ports for internal services and switching hardcoded credentials to environment variables. Frontend now calls backend services via internal Docker hostnames to avoid localhost coupling.

- **Refactors**
  - Removed host port mappings for Postgres, Redis, Vault, Prometheus, Grafana, Mailhog, and backend services.
  - Replaced inline credentials with env vars (DATABASE_URL, REDIS_URL, VAULT_URL, POSTGRES_*, GF_SECURITY_ADMIN_PASSWORD, VAULT_DEV_ROOT_TOKEN_ID).
  - Pointed frontend to internal URLs: smm-architect-service:4000 and smm-toolhub:3001.
  - Updated Postgres healthcheck to use POSTGRES_USER.

- **Migration**
  - Create a .env with: POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_TEST_USER, POSTGRES_TEST_PASSWORD, DATABASE_URL, REDIS_URL, VAULT_URL, VAULT_DEV_ROOT_TOKEN_ID, GF_SECURITY_ADMIN_PASSWORD, SENTRY_DSN, OPENAI_API_KEY.
  - Need direct host access to internal tools (Grafana/Prometheus/Mailhog/Vault/Postgres/Redis)? Temporarily re-add port mappings or use docker exec/port-forwarding.

<!-- End of auto-generated description by cubic. -->

