### PR TITLE
chore: pin docker-compose image versions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,7 +132,7 @@ services:
 
   # Monitoring Services
   prometheus:
-    image: prom/prometheus:latest
+    image: prom/prometheus:v2.47.0
     container_name: smm-prometheus
     ports:
       - "9090:9090"
@@ -150,7 +150,7 @@ services:
     restart: unless-stopped
 
   grafana:
-    image: grafana/grafana:latest
+    image: grafana/grafana:10.1.0
     container_name: smm-grafana
     ports:
       - "3001:3000"
@@ -165,7 +165,7 @@ services:
 
   # Development Tools
   mailhog:
-    image: mailhog/mailhog:latest
+    image: mailhog/mailhog:v1.0.1
     container_name: smm-mailhog
     ports:
       - "8025:8025"  # Web interface


### PR DESCRIPTION
## Summary
- pin Prometheus, Grafana, and MailHog images to explicit versions in docker-compose

## Testing
- `make test` *(fails: turbo: not found)*
- `make test-security` *(fails: missing row level security policies)*

------
https://chatgpt.com/codex/tasks/task_e_68b97d310b74832bade96a9fc5263ba9
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Pinned Prometheus, Grafana, and MailHog images in docker-compose to fixed versions to ensure reproducible local environments and avoid breaking changes from latest tags.

- **Dependencies**
  - prom/prometheus:v2.47.0
  - grafana/grafana:10.1.0
  - mailhog/mailhog:v1.0.1

<!-- End of auto-generated description by cubic. -->

