### PR TITLE
refactor: externalize secrets in compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,23 @@
 # Sentry Configuration
-SENTRY_DSN=https://02a82d6e1d09e631f5ef7083e197c841@o4509899378786304.ingest.de.sentry.io/4509899558879312
-NEXT_PUBLIC_SENTRY_DSN=https://02a82d6e1d09e631f5ef7083e197c841@o4509899378786304.ingest.de.sentry.io/4509899558879312
+SENTRY_DSN=your_sentry_dsn
+NEXT_PUBLIC_SENTRY_DSN=your_sentry_dsn
 SENTRY_ENABLED=true
 
 # Application Configuration
 NODE_ENV=development
 PORT=3000
 
+# Database
+POSTGRES_PASSWORD=change_me
+DATABASE_URL=postgresql://smm_user:${POSTGRES_PASSWORD}@postgres:5432/smm_architect
+POSTGRES_TEST_PASSWORD=change_me
+
+# Third-Party Services
+OPENAI_API_KEY=your_openai_api_key
+VAULT_DEV_ROOT_TOKEN_ID=your_vault_token
+GF_SECURITY_ADMIN_PASSWORD=change_me
+
 # Optional: Sentry Release Tracking
 npm_package_version=1.0.0
 APP_VERSION=1.0.0
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     environment:
       POSTGRES_DB: smm_architect
       POSTGRES_USER: smm_user
-      POSTGRES_PASSWORD: smm_password
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_MULTIPLE_DATABASES: smm_architect,smm_test
     ports:
       - "5432:5432"
@@ -49,7 +49,7 @@ services:
     environment:
       - NODE_ENV=development
       - PORT=4000
-      - DATABASE_URL=postgresql://smm_user:smm_password@postgres:5432/smm_architect
+      - DATABASE_URL=${DATABASE_URL}
       - REDIS_URL=redis://redis:6379
       - VAULT_URL=http://vault:8200
       - SENTRY_DSN=${SENTRY_DSN}
@@ -75,7 +75,7 @@ services:
     environment:
       - NODE_ENV=development
       - PORT=3001
-      - DATABASE_URL=postgresql://smm_user:smm_password@postgres:5432/smm_architect
+      - DATABASE_URL=${DATABASE_URL}
       - REDIS_URL=redis://redis:6379
       - VAULT_URL=http://vault:8200
       - SENTRY_DSN=${SENTRY_DSN}
@@ -120,7 +120,7 @@ services:
     ports:
       - "8200:8200"
     environment:
-      - VAULT_DEV_ROOT_TOKEN_ID=dev-root-token
+      - VAULT_DEV_ROOT_TOKEN_ID=${VAULT_DEV_ROOT_TOKEN_ID}
       - VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:8200
     cap_add:
       - IPC_LOCK
@@ -155,7 +155,7 @@ services:
     ports:
       - "3001:3000"
     environment:
-      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_SECURITY_ADMIN_PASSWORD=${GF_SECURITY_ADMIN_PASSWORD}
     volumes:
       - grafana_data:/var/lib/grafana
       - ./monitoring/dashboards:/etc/grafana/provisioning/dashboards
@@ -180,7 +180,7 @@ services:
     environment:
       POSTGRES_DB: smm_test
       POSTGRES_USER: smm_test
-      POSTGRES_PASSWORD: smm_test
+      POSTGRES_PASSWORD: ${POSTGRES_TEST_PASSWORD}
     ports:
       - "5433:5432"
     volumes:


### PR DESCRIPTION
## Summary
- externalize PostgreSQL, Vault, and Grafana secrets in docker-compose
- document required environment variables in .env.example

## Testing
- `make test` *(fails: command exited with code 1)*
- `make test-security` *(fails: RLS policy requirements unmet)*

------
https://chatgpt.com/codex/tasks/task_e_68b97d2e6000832b80a3b46c901b8dcd