### PR TITLE
chore: specify supported node engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "description": "QA & Validation framework for SMM Architect",
   "packageManager": "pnpm@8.15.0",
+  "engines": {
+    "node": ">=18.x"
+  },
   "scripts": {
     "build": "turbo build",
     "dev": "turbo dev",


### PR DESCRIPTION
## Summary
- declare supported Node.js version in package engines

## Testing
- `make test` *(fails: turbo: not found)*
- `make test-security` *(fails: migration RLS linter detected violations)*

------
https://chatgpt.com/codex/tasks/task_e_68b97d2a5df8832bb94e1a30704514c7
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Declare Node.js >=18.x in package.json engines to standardize the runtime across local, CI, and production. Prevents installs/builds with unsupported Node versions.

<!-- End of auto-generated description by cubic. -->

