### PR TITLE
Add MIT license file and update README badge

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 SMM Architect Team
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SMM Architect
 
 [![CI Status](https://github.com/yourorg/smm-architect/workflows/CI/badge.svg)](https://github.com/yourorg/smm-architect/actions)
-[![License](https://img.shields.io/badge/license-Proprietary-red.svg)](LICENSE)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Version](https://img.shields.io/badge/version-1.0.0-blue.svg)](CHANGELOG.md)
 [![Status](https://img.shields.io/badge/status-Production%20Ready-brightgreen.svg)](AGENTS.md)
 
@@ -453,7 +453,7 @@ See `examples/workspace-contract.icblabs.json` for a complete example workspace 
 
 ## 📄 License
 
-This project is proprietary software. See [LICENSE](LICENSE) for details.
+This project is licensed under the [MIT License](LICENSE).
 
 ## 🙋‍♀️ Support
 


### PR DESCRIPTION
## Summary
- add MIT license file to clarify project licensing
- update README badge and license section to reference MIT license

## Testing
- `npm test` *(fails: build command exited 1)*
- `npm run test:security` *(fails: missing modules such as generated client)*
- `make test` *(fails: build command exited 1)*
- `make test-security` *(fails: RLS violations in migrations)*

------
https://chatgpt.com/codex/tasks/task_e_68b97d22e0e4832bbad4ca16e0014f72
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added an MIT LICENSE file and updated the README badge and license section to reflect MIT licensing. This clarifies the project’s license and aligns badges and docs.

<!-- End of auto-generated description by cubic. -->

