### PR TITLE
Use real tenant roles for DSR admin checks

### DIFF
--- a/services/dsr/src/dsr-api.ts
+++ b/services/dsr/src/dsr-api.ts
@@ -1,6 +1,6 @@
 /**
  * Data Subject Rights (DSR) API Endpoints
- * 
+ *
  * REST API for handling GDPR/CCPA data subject rights requests:
  * - POST /dsr/export - Generate data export (Right to Access)
  * - POST /dsr/delete - Process deletion request (Right to Erasure)
@@ -8,44 +8,53 @@
  * - GET /dsr/status/:requestId - Check request status
  */
 
-import express, { Request, Response } from 'express';
-import { body, param, validationResult } from 'express-validator';
-import rateLimit from 'express-rate-limit';
-import { authMiddleware, requirePermissions } from '../../shared/middleware/auth-middleware';
-import { DataSubjectRightsService, DSRRequest } from './data-subject-rights-service';
-import { withTenantContext, withRetryTransaction } from '../../shared/database/client';
-import { VaultClient } from '../../shared/vault-client';
-import winston from 'winston';
-import crypto from 'crypto';
-import { promisify } from 'util';
-import { pipeline } from 'stream';
-import archiver from 'archiver';
+import express, { Request, Response } from "express";
+import { body, param, validationResult } from "express-validator";
+import rateLimit from "express-rate-limit";
+import {
+  authMiddleware,
+  requirePermissions,
+} from "../../shared/middleware/auth-middleware";
+import {
+  DataSubjectRightsService,
+  DSRRequest,
+} from "./data-subject-rights-service";
+import {
+  withTenantContext,
+  withRetryTransaction,
+} from "../../shared/database/client";
+import { VaultClient } from "../../shared/vault-client";
+import winston from "winston";
+import crypto from "crypto";
+import { promisify } from "util";
+import { pipeline } from "stream";
+import archiver from "archiver";
 
 const logger = winston.createLogger({
-  level: process.env.LOG_LEVEL || 'info',
+  level: process.env.LOG_LEVEL || "info",
   format: winston.format.combine(
     winston.format.timestamp(),
-    winston.format.json()
+    winston.format.json(),
   ),
   transports: [
     new winston.transports.Console(),
-    new winston.transports.File({ filename: 'dsr-api.log' })
-  ]
+    new winston.transports.File({ filename: "dsr-api.log" }),
+  ],
 });
 
 const app = express();
 
 // Apply authentication to all DSR endpoints
-app.use('/api', authMiddleware());
-app.use('/api/dsr', requirePermissions('dsr:access'));
+app.use("/api", authMiddleware());
+app.use("/api/dsr", requirePermissions("dsr:access"));
 
 // Additional permission requirements for specific operations
-app.use('/api/dsr/delete', requirePermissions('dsr:delete'));
-app.use('/api/dsr/export', requirePermissions('dsr:export'));
-app.use('/api/dsr/rectify', requirePermissions('dsr:rectify'));
+app.use("/api/dsr/delete", requirePermissions("dsr:delete"));
+app.use("/api/dsr/export", requirePermissions("dsr:export"));
+app.use("/api/dsr/rectify", requirePermissions("dsr:rectify"));
 
 // Middleware
-app.use(express.json({ limit: '10mb' }));
+app.use(express.json({ limit: "10mb" }));
 app.use(express.urlencoded({ extended: true }));
 
 // Rate limiting for DSR endpoints (stricter limits)
@@ -53,39 +62,46 @@ const dsrRateLimit = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
   max: 5, // Maximum 5 DSR requests per 15 minutes per IP
   message: {
-    error: 'Too many DSR requests. Please try again later.',
-    retryAfter: '15 minutes'
+    error: "Too many DSR requests. Please try again later.",
+    retryAfter: "15 minutes",
   },
   standardHeaders: true,
-  legacyHeaders: false
+  legacyHeaders: false,
 });
 
 // Initialize services
 // Database client is accessed securely via withTenantContext()
 const vaultClient = new VaultClient({
-  address: process.env.VAULT_ADDR || 'http://localhost:8200',
-  token: process.env.VAULT_TOKEN
+  address: process.env.VAULT_ADDR || "http://localhost:8200",
+  token: process.env.VAULT_TOKEN,
 });
 
 // DSR service will be instantiated per request with proper tenant context
 // const dsrService = new DataSubjectRightsService(prisma, vaultClient);
 
 // Request storage (in production, use Redis or database)
-const requestStore = new Map<string, DSRRequest & { status: string; result?: any }>();
+const requestStore = new Map<
+  string,
+  DSRRequest & { status: string; result?: any }
+>();
 
 /**
  * POST /api/dsr/export
  * Generate data export for data subject (Right to Access - GDPR Article 15)
  */
-app.post('/api/dsr/export',
+app.post(
+  "/api/dsr/export",
   dsrRateLimit,
   [
-    body('userId').isString().isLength({ min: 1, max: 255 }).trim(),
-    body('tenantId').isString().isLength({ min: 1, max: 255 }).trim(),
-    body('userEmail').isEmail().normalizeEmail(),
-    body('requestedBy').isString().isLength({ min: 1, max: 255 }).trim(),
-    body('verificationToken').optional().isString().isLength({ min: 32, max: 512 }),
-    body('reason').optional().isString().isLength({ max: 1000 }).trim()
+    body("userId").isString().isLength({ min: 1, max: 255 }).trim(),
+    body("tenantId").isString().isLength({ min: 1, max: 255 }).trim(),
+    body("userEmail").isEmail().normalizeEmail(),
+    body("requestedBy").isString().isLength({ min: 1, max: 255 }).trim(),
+    body("verificationToken")
+      .optional()
+      .isString()
+      .isLength({ min: 32, max: 512 }),
+    body("reason").optional().isString().isLength({ max: 1000 }).trim(),
   ],
   async (req: Request, res: Response) => {
     try {
@@ -93,21 +109,28 @@ app.post('/api/dsr/export',
       const errors = validationResult(req);
       if (!errors.isEmpty()) {
         return res.status(400).json({
-          error: 'Validation failed',
-          details: errors.array()
+          error: "Validation failed",
+          details: errors.array(),
         });
       }
 
-      const { userId, tenantId, userEmail, requestedBy, verificationToken, reason } = req.body;
+      const {
+        userId,
+        tenantId,
+        userEmail,
+        requestedBy,
+        verificationToken,
+        reason,
+      } = req.body;
       const requestId = `export_${crypto.randomUUID()}`;
 
-      logger.info('DSR export request received', {
+      logger.info("DSR export request received", {
         requestId,
         userId,
         tenantId,
         userEmail,
         requestedBy,
-        ip: req.ip
+        ip: req.ip,
       });
 
       // Verify user identity (in production, implement proper verification)
@@ -115,7 +138,7 @@ app.post('/api/dsr/export',
         const isValidToken = await verifyUserToken(userId, verificationToken);
         if (!isValidToken) {
           return res.status(403).json({
-            error: 'Invalid verification token'
+            error: "Invalid verification token",
           });
         }
       }
@@ -123,122 +146,127 @@ app.post('/api/dsr/export',
       // Store request
       const dsrRequest: DSRRequest = {
         requestId,
-        requestType: 'access',
+        requestType: "access",
         userId,
         tenantId,
         userEmail,
         requestedBy,
         requestedAt: new Date().toISOString(),
         reason,
-        verificationToken
+        verificationToken,
       };
 
-      requestStore.set(requestId, { 
-        ...dsrRequest, 
-        status: 'processing' 
+      requestStore.set(requestId, {
+        ...dsrRequest,
+        status: "processing",
       });
 
       // Process export asynchronously
-      processExportRequest(requestId, dsrRequest).catch(error => {
-        logger.error('Export processing failed', { requestId, error });
+      processExportRequest(requestId, dsrRequest).catch((error) => {
+        logger.error("Export processing failed", { requestId, error });
         const stored = requestStore.get(requestId);
         if (stored) {
-          stored.status = 'failed';
+          stored.status = "failed";
           stored.result = { error: error.message };
         }
       });
 
       return res.status(202).json({
         requestId,
-        status: 'accepted',
-        message: 'Export request accepted for processing',
-        estimatedCompletion: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(), // 24 hours
-        statusUrl: `/dsr/status/${requestId}`
+        status: "accepted",
+        message: "Export request accepted for processing",
+        estimatedCompletion: new Date(
+          Date.now() + 24 * 60 * 60 * 1000,
+        ).toISOString(), // 24 hours
+        statusUrl: `/dsr/status/${requestId}`,
       });
-
     } catch (error) {
-      logger.error('DSR export endpoint error', {
+      logger.error("DSR export endpoint error", {
         error: error instanceof Error ? error.message : error,
-        ip: req.ip
+        ip: req.ip,
       });
 
       return res.status(500).json({
-        error: 'Internal server error processing export request'
+        error: "Internal server error processing export request",
       });
     }
-  }
+  },
 );
 
 /**
  * POST /api/dsr/delete
  * Process deletion request (Right to Erasure - GDPR Article 17)
  */
-app.post('/api/dsr/delete',
+app.post(
+  "/api/dsr/delete",
   dsrRateLimit,
   [
-    body('userId').isString().isLength({ min: 1, max: 255 }).trim(),
-    body('tenantId').isString().isLength({ min: 1, max: 255 }).trim(),
-    body('userEmail').isEmail().normalizeEmail(),
-    body('requestedBy').isString().isLength({ min: 1, max: 255 }).trim(),
-    body('scope').optional().isIn(['user', 'tenant', 'workspace']),
-    body('retentionOverride').optional().isBoolean(),
-    body('verificationToken').isString().isLength({ min: 32, max: 512 }),
-    body('reason').isString().isLength({ min: 10, max: 1000 }).trim()
+    body("userId").isString().isLength({ min: 1, max: 255 }).trim(),
+    body("tenantId").isString().isLength({ min: 1, max: 255 }).trim(),
+    body("userEmail").isEmail().normalizeEmail(),
+    body("requestedBy").isString().isLength({ min: 1, max: 255 }).trim(),
+    body("scope").optional().isIn(["user", "tenant", "workspace"]),
+    body("retentionOverride").optional().isBoolean(),
+    body("verificationToken").isString().isLength({ min: 32, max: 512 }),
+    body("reason").isString().isLength({ min: 10, max: 1000 }).trim(),
   ],
   async (req: Request, res: Response) => {
     try {
       const errors = validationResult(req);
       if (!errors.isEmpty()) {
         return res.status(400).json({
-          error: 'Validation failed',
-          details: errors.array()
+          error: "Validation failed",
+          details: errors.array(),
         });
       }
 
-      const { 
-        userId, 
-        tenantId, 
-        userEmail, 
-        requestedBy, 
-        scope = 'user', 
+      const {
+        userId,
+        tenantId,
+        userEmail,
+        requestedBy,
+        scope = "user",
         retentionOverride = false,
         verificationToken,
-        reason 
+        reason,
       } = req.body;
-      
+
       const requestId = `delete_${crypto.randomUUID()}`;
 
-      logger.info('DSR deletion request received', {
+      logger.info("DSR deletion request received", {
         requestId,
         userId,
         tenantId,
         userEmail,
         requestedBy,
         scope,
-        ip: req.ip
+        ip: req.ip,
       });
 
       // Verify user identity (CRITICAL for deletion requests)
       const isValidToken = await verifyUserToken(userId, verificationToken);
       if (!isValidToken) {
         return res.status(403).json({
-          error: 'Invalid verification token. Deletion request denied.'
+          error: "Invalid verification token. Deletion request denied.",
         });
       }
 
       // Additional security check for tenant/workspace scope deletions
-      if (scope !== 'user') {
-        const hasAdminPermission = await verifyAdminPermission(requestedBy, tenantId);
+      if (scope !== "user") {
+        const hasAdminPermission = await verifyAdminPermission(
+          requestedBy,
+          tenantId,
+        );
         if (!hasAdminPermission) {
           return res.status(403).json({
-            error: 'Insufficient permissions for scope-level deletion'
+            error: "Insufficient permissions for scope-level deletion",
           });
         }
       }
 
       const dsrRequest: DSRRequest = {
         requestId,
-        requestType: 'deletion',
+        requestType: "deletion",
         userId,
         tenantId,
         userEmail,
@@ -246,159 +274,176 @@ app.post('/api/dsr/delete',
         requestedAt: new Date().toISOString(),
         reason,
         verificationToken,
-        retentionOverride
+        retentionOverride,
       };
 
-      requestStore.set(requestId, { 
-        ...dsrRequest, 
-        status: 'processing' 
+      requestStore.set(requestId, {
+        ...dsrRequest,
+        status: "processing",
       });
 
       // Process deletion asynchronously
-      processDeletionRequest(requestId, dsrRequest, { 
-        scope, 
-        retentionOverride, 
-        requestedBy, 
-        reason 
-      }).catch(error => {
-        logger.error('Deletion processing failed', { requestId, error });
+      processDeletionRequest(requestId, dsrRequest, {
+        scope,
+        retentionOverride,
+        requestedBy,
+        reason,
+      }).catch((error) => {
+        logger.error("Deletion processing failed", { requestId, error });
         const stored = requestStore.get(requestId);
         if (stored) {
-          stored.status = 'failed';
+          stored.status = "failed";
           stored.result = { error: error.message };
         }
       });
 
       return res.status(202).json({
         requestId,
-        status: 'accepted',
-        message: 'Deletion request accepted for processing',
-        estimatedCompletion: new Date(Date.now() + 72 * 60 * 60 * 1000).toISOString(), // 72 hours
+        status: "accepted",
+        message: "Deletion request accepted for processing",
+        estimatedCompletion: new Date(
+          Date.now() + 72 * 60 * 60 * 1000,
+        ).toISOString(), // 72 hours
         statusUrl: `/dsr/status/${requestId}`,
-        warning: 'This action is irreversible. All data will be permanently deleted.'
+        warning:
+          "This action is irreversible. All data will be permanently deleted.",
       });
-
     } catch (error) {
-      logger.error('DSR deletion endpoint error', {
+      logger.error("DSR deletion endpoint error", {
         error: error instanceof Error ? error.message : error,
-        ip: req.ip
+        ip: req.ip,
       });
 
       return res.status(500).json({
-        error: 'Internal server error processing deletion request'
+        error: "Internal server error processing deletion request",
       });
     }
-  }
+  },
 );
 
 /**
  * POST /api/dsr/rectify
  * Process rectification request (Right to Rectification - GDPR Article 16)
  */
-app.post('/api/dsr/rectify',
+app.post(
+  "/api/dsr/rectify",
   dsrRateLimit,
   [
-    body('userId').isString().isLength({ min: 1, max: 255 }).trim(),
-    body('tenantId').isString().isLength({ min: 1, max: 255 }).trim(),
-    body('userEmail').isEmail().normalizeEmail(),
-    body('requestedBy').isString().isLength({ min: 1, max: 255 }).trim(),
-    body('corrections').isObject(),
-    body('verificationToken').isString().isLength({ min: 32, max: 512 }),
-    body('reason').optional().isString().isLength({ max: 1000 }).trim()
+    body("userId").isString().isLength({ min: 1, max: 255 }).trim(),
+    body("tenantId").isString().isLength({ min: 1, max: 255 }).trim(),
+    body("userEmail").isEmail().normalizeEmail(),
+    body("requestedBy").isString().isLength({ min: 1, max: 255 }).trim(),
+    body("corrections").isObject(),
+    body("verificationToken").isString().isLength({ min: 32, max: 512 }),
+    body("reason").optional().isString().isLength({ max: 1000 }).trim(),
   ],
   async (req: Request, res: Response) => {
     try {
       const errors = validationResult(req);
       if (!errors.isEmpty()) {
         return res.status(400).json({
-          error: 'Validation failed',
-          details: errors.array()
+          error: "Validation failed",
+          details: errors.array(),
         });
       }
 
-      const { userId, tenantId, userEmail, requestedBy, corrections, verificationToken, reason } = req.body;
+      const {
+        userId,
+        tenantId,
+        userEmail,
+        requestedBy,
+        corrections,
+        verificationToken,
+        reason,
+      } = req.body;
       const requestId = `rectify_${crypto.randomUUID()}`;
 
-      logger.info('DSR rectification request received', {
+      logger.info("DSR rectification request received", {
         requestId,
         userId,
         tenantId,
         userEmail,
         requestedBy,
         correctionFields: Object.keys(corrections),
-        ip: req.ip
+        ip: req.ip,
       });
 
       // Verify user identity
       const isValidToken = await verifyUserToken(userId, verificationToken);
       if (!isValidToken) {
         return res.status(403).json({
-          error: 'Invalid verification token'
+          error: "Invalid verification token",
         });
       }
 
       const dsrRequest: DSRRequest = {
         requestId,
-        requestType: 'rectification',
+        requestType: "rectification",
         userId,
         tenantId,
         userEmail,
         requestedBy,
         requestedAt: new Date().toISOString(),
         reason,
-        verificationToken
+        verificationToken,
       };
 
-      requestStore.set(requestId, { 
-        ...dsrRequest, 
-        status: 'processing' 
+      requestStore.set(requestId, {
+        ...dsrRequest,
+        status: "processing",
       });
 
       // Process rectification asynchronously
-      processRectificationRequest(requestId, dsrRequest, corrections).catch(error => {
-        logger.error('Rectification processing failed', { requestId, error });
-        const stored = requestStore.get(requestId);
-        if (stored) {
-          stored.status = 'failed';
-          stored.result = { error: error.message };
-        }
-      });
+      processRectificationRequest(requestId, dsrRequest, corrections).catch(
+        (error) => {
+          logger.error("Rectification processing failed", { requestId, error });
+          const stored = requestStore.get(requestId);
+          if (stored) {
+            stored.status = "failed";
+            stored.result = { error: error.message };
+          }
+        },
+      );
 
       return res.status(202).json({
         requestId,
-        status: 'accepted',
-        message: 'Rectification request accepted for processing',
-        estimatedCompletion: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
-        statusUrl: `/dsr/status/${requestId}`
+        status: "accepted",
+        message: "Rectification request accepted for processing",
+        estimatedCompletion: new Date(
+          Date.now() + 24 * 60 * 60 * 1000,
+        ).toISOString(),
+        statusUrl: `/dsr/status/${requestId}`,
       });
-
     } catch (error) {
-      logger.error('DSR rectification endpoint error', {
+      logger.error("DSR rectification endpoint error", {
         error: error instanceof Error ? error.message : error,
-        ip: req.ip
+        ip: req.ip,
       });
 
       return res.status(500).json({
-        error: 'Internal server error processing rectification request'
+        error: "Internal server error processing rectification request",
       });
     }
-  }
+  },
 );
 
 /**
  * GET /api/dsr/status/:requestId
  * Check the status of a DSR request
  */
-app.get('/api/dsr/status/:requestId',
+app.get(
+  "/api/dsr/status/:requestId",
   [
-    param('requestId').isString().matches(/^(export|delete|rectify)_[a-f0-9-]{36}$/)
+    param("requestId")
+      .isString()
+      .matches(/^(export|delete|rectify)_[a-f0-9-]{36}$/),
   ],
   async (req: Request, res: Response) => {
     try {
       const errors = validationResult(req);
       if (!errors.isEmpty()) {
         return res.status(400).json({
-          error: 'Invalid request ID format'
+          error: "Invalid request ID format",
         });
       }
 
@@ -407,7 +452,7 @@ app.get('/api/dsr/status/:requestId',
 
       if (!stored) {
         return res.status(404).json({
-          error: 'Request not found'
+          error: "Request not found",
         });
       }
 
@@ -416,281 +461,328 @@ app.get('/api/dsr/status/:requestId',
         requestType: stored.requestType,
         status: stored.status,
         requestedAt: stored.requestedAt,
-        lastUpdated: new Date().toISOString()
+        lastUpdated: new Date().toISOString(),
       };
 
       // Add result details based on status
-      if (stored.status === 'completed' && stored.result) {
-        if (stored.requestType === 'access') {
+      if (stored.status === "completed" && stored.result) {
+        if (stored.requestType === "access") {
           response.downloadUrl = `/api/dsr/download/${requestId}`;
           response.dataSize = stored.result.metadata?.exportSize;
           response.recordCount = stored.result.metadata?.totalRecords;
-        } else if (stored.requestType === 'deletion') {
+        } else if (stored.requestType === "deletion") {
           response.recordsDeleted = stored.result.subsystemResults?.reduce(
-            (sum: number, r: any) => sum + r.recordsDeleted, 0
+            (sum: number, r: any) => sum + r.recordsDeleted,
+            0,
           );
           response.deletionReport = stored.result.integrityHash;
-        } else if (stored.requestType === 'rectification') {
+        } else if (stored.requestType === "rectification") {
           response.recordsUpdated = stored.result.recordsUpdated;
         }
-      } else if (stored.status === 'failed' && stored.result?.error) {
+      } else if (stored.status === "failed" && stored.result?.error) {
         response.error = stored.result.error;
       }
 
       return res.json(response);
-
     } catch (error) {
-      logger.error('DSR status endpoint error', {
+      logger.error("DSR status endpoint error", {
         error: error instanceof Error ? error.message : error,
-        requestId: req.params.requestId
+        requestId: req.params.requestId,
       });
 
       return res.status(500).json({
-        error: 'Internal server error checking request status'
+        error: "Internal server error checking request status",
       });
     }
-  }
+  },
 );
 
 /**
  * GET /api/dsr/download/:requestId
  * Download exported data (for completed export requests)
  */
-app.get('/api/dsr/download/:requestId',
+app.get(
+  "/api/dsr/download/:requestId",
   [
-    param('requestId').isString().matches(/^export_[a-f0-9-]{36}$/)
+    param("requestId")
+      .isString()
+      .matches(/^export_[a-f0-9-]{36}$/),
   ],
   async (req: Request, res: Response) => {
     try {
       const { requestId } = req.params;
       const stored = requestStore.get(requestId);
 
-      if (!stored || stored.requestType !== 'access' || stored.status !== 'completed') {
+      if (
+        !stored ||
+        stored.requestType !== "access" ||
+        stored.status !== "completed"
+      ) {
         return res.status(404).json({
-          error: 'Export data not available'
+          error: "Export data not available",
         });
       }
 
       const exportData = stored.result;
       if (!exportData) {
         return res.status(404).json({
-          error: 'Export data not found'
+          error: "Export data not found",
         });
       }
 
       // Set headers for file download
-      res.setHeader('Content-Type', 'application/zip');
-      res.setHeader('Content-Disposition', `attachment; filename="data-export-${requestId}.zip"`);
+      res.setHeader("Content-Type", "application/zip");
+      res.setHeader(
+        "Content-Disposition",
+        `attachment; filename="data-export-${requestId}.zip"`,
+      );
 
       // Create ZIP archive
-      const archive = archiver('zip', { zlib: { level: 9 } });
-      
-      archive.on('error', (err) => {
-        logger.error('Archive creation error', { requestId, error: err });
-        res.status(500).json({ error: 'Failed to create export archive' });
+      const archive = archiver("zip", { zlib: { level: 9 } });
+
+      archive.on("error", (err) => {
+        logger.error("Archive creation error", { requestId, error: err });
+        res.status(500).json({ error: "Failed to create export archive" });
       });
 
       archive.pipe(res);
 
       // Add data files to archive
-      archive.append(JSON.stringify(exportData, null, 2), { name: 'personal-data.json' });
-      archive.append(JSON.stringify(exportData.metadata, null, 2), { name: 'export-metadata.json' });
-      
+      archive.append(JSON.stringify(exportData, null, 2), {
+        name: "personal-data.json",
+      });
+      archive.append(JSON.stringify(exportData.metadata, null, 2), {
+        name: "export-metadata.json",
+      });
+
       // Add audit information
       const auditInfo = {
         exportId: exportData.exportId,
         generatedAt: exportData.generatedAt,
         requestId,
-        integrityHash: exportData.metadata.integrityHash
+        integrityHash: exportData.metadata.integrityHash,
       };
-      archive.append(JSON.stringify(auditInfo, null, 2), { name: 'audit-info.json' });
+      archive.append(JSON.stringify(auditInfo, null, 2), {
+        name: "audit-info.json",
+      });
 
       await archive.finalize();
 
-      logger.info('Data export downloaded', {
+      logger.info("Data export downloaded", {
         requestId,
         userId: stored.userId,
-        ip: req.ip
+        ip: req.ip,
       });
-
     } catch (error) {
-      logger.error('DSR download endpoint error', {
+      logger.error("DSR download endpoint error", {
         error: error instanceof Error ? error.message : error,
-        requestId: req.params.requestId
+        requestId: req.params.requestId,
       });
 
       return res.status(500).json({
-        error: 'Internal server error downloading export'
+        error: "Internal server error downloading export",
       });
     }
-  }
+  },
 );
 
 // Error handling middleware
 app.use((error: Error, req: Request, res: Response, next: any) => {
-  logger.error('Unhandled DSR API error', {
+  logger.error("Unhandled DSR API error", {
     error: error.message,
     stack: error.stack,
     path: req.path,
-    method: req.method
+    method: req.method,
   });
 
   res.status(500).json({
-    error: 'Internal server error'
+    error: "Internal server error",
   });
 });
 
 // Background processing functions
-async function processExportRequest(requestId: string, dsrRequest: DSRRequest): Promise<void> {
+async function processExportRequest(
+  requestId: string,
+  dsrRequest: DSRRequest,
+): Promise<void> {
   try {
-    logger.info('Processing export request', { requestId });
-    
+    logger.info("Processing export request", { requestId });
+
     // Create DSR service with proper tenant context
-    const exportData = await withTenantContext(dsrRequest.tenantId, async (client) => {
-      const dsrService = new DataSubjectRightsService(client, vaultClient);
-      return await dsrService.generateDataExport(
-        dsrRequest.userId,
-        dsrRequest.tenantId
-      );
-    });
+    const exportData = await withTenantContext(
+      dsrRequest.tenantId,
+      async (client) => {
+        const dsrService = new DataSubjectRightsService(client, vaultClient);
+        return await dsrService.generateDataExport(
+          dsrRequest.userId,
+          dsrRequest.tenantId,
+        );
+      },
+    );
 
     const stored = requestStore.get(requestId);
     if (stored) {
-      stored.status = 'completed';
+      stored.status = "completed";
       stored.result = exportData;
     }
 
-    logger.info('Export request completed', { 
-      requestId, 
-      totalRecords: exportData.metadata.totalRecords 
+    logger.info("Export request completed", {
+      requestId,
+      totalRecords: exportData.metadata.totalRecords,
     });
-
   } catch (error) {
-    logger.error('Export request processing failed', { requestId, error });
+    logger.error("Export request processing failed", { requestId, error });
     throw error;
   }
 }
 
 async function processDeletionRequest(
-  requestId: string, 
-  dsrRequest: DSRRequest, 
-  options: any
+  requestId: string,
+  dsrRequest: DSRRequest,
+  options: any,
 ): Promise<void> {
   try {
-    logger.info('Processing deletion request', { requestId });
-    
+    logger.info("Processing deletion request", { requestId });
+
     // Create DSR service with proper tenant context
-    const deletionReport = await withTenantContext(dsrRequest.tenantId, async (client) => {
-      const dsrService = new DataSubjectRightsService(client, vaultClient);
-      return await dsrService.processErasureRequest(
-        requestId,
-        dsrRequest.userId,
-        dsrRequest.tenantId,
-        options
-      );
-    });
+    const deletionReport = await withTenantContext(
+      dsrRequest.tenantId,
+      async (client) => {
+        const dsrService = new DataSubjectRightsService(client, vaultClient);
+        return await dsrService.processErasureRequest(
+          requestId,
+          dsrRequest.userId,
+          dsrRequest.tenantId,
+          options,
+        );
+      },
+    );
 
     const stored = requestStore.get(requestId);
     if (stored) {
-      stored.status = 'completed';
+      stored.status = "completed";
       stored.result = deletionReport;
     }
 
-    logger.info('Deletion request completed', { 
-      requestId, 
+    logger.info("Deletion request completed", {
+      requestId,
       recordsDeleted: deletionReport.subsystemResults.reduce(
-        (sum, r) => sum + r.recordsDeleted, 0
-      )
+        (sum, r) => sum + r.recordsDeleted,
+        0,
+      ),
     });
-
   } catch (error) {
-    logger.error('Deletion request processing failed', { requestId, error });
+    logger.error("Deletion request processing failed", { requestId, error });
     throw error;
   }
 }
 
 async function processRectificationRequest(
-  requestId: string, 
-  dsrRequest: DSRRequest, 
-  corrections: any
+  requestId: string,
+  dsrRequest: DSRRequest,
+  corrections: any,
 ): Promise<void> {
   try {
-    logger.info('Processing rectification request', { requestId });
-    
+    logger.info("Processing rectification request", { requestId });
+
     // Create DSR service with proper tenant context
-    const result = await withTenantContext(dsrRequest.tenantId, async (client) => {
-      const dsrService = new DataSubjectRightsService(client, vaultClient);
-      return await dsrService.processRectificationRequest(
-        dsrRequest.userId,
-        dsrRequest.tenantId,
-        corrections
-      );
-    });
+    const result = await withTenantContext(
+      dsrRequest.tenantId,
+      async (client) => {
+        const dsrService = new DataSubjectRightsService(client, vaultClient);
+        return await dsrService.processRectificationRequest(
+          dsrRequest.userId,
+          dsrRequest.tenantId,
+          corrections,
+        );
+      },
+    );
 
     const stored = requestStore.get(requestId);
     if (stored) {
-      stored.status = 'completed';
+      stored.status = "completed";
       stored.result = result;
     }
 
-    logger.info('Rectification request completed', { 
-      requestId, 
-      recordsUpdated: result.recordsUpdated 
+    logger.info("Rectification request completed", {
+      requestId,
+      recordsUpdated: result.recordsUpdated,
     });
-
   } catch (error) {
-    logger.error('Rectification request processing failed', { requestId, error });
+    logger.error("Rectification request processing failed", {
+      requestId,
+      error,
+    });
     throw error;
   }
 }
 
 // Helper functions
-async function verifyUserToken(userId: string, token: string): Promise<boolean> {
+async function verifyUserToken(
+  userId: string,
+  token: string,
+): Promise<boolean> {
   try {
     // Mock verification - in production, verify against secure token store
-    const expectedToken = crypto.createHash('sha256')
-      .update(`${userId}:${process.env.DSR_SECRET || 'dev-secret'}`)
-      .digest('hex');
-    return crypto.timingSafeEqual(Buffer.from(token), Buffer.from(expectedToken));
+    const expectedToken = crypto
+      .createHash("sha256")
+      .update(`${userId}:${process.env.DSR_SECRET || "dev-secret"}`)
+      .digest("hex");
+    return crypto.timingSafeEqual(
+      Buffer.from(token),
+      Buffer.from(expectedToken),
+    );
   } catch (error) {
-    logger.error('Token verification failed', { userId, error });
+    logger.error("Token verification failed", { userId, error });
     return false;
   }
 }
 
-async function verifyAdminPermission(requestedBy: string, tenantId: string): Promise<boolean> {
+export async function verifyAdminPermission(
+  requestedBy: string,
+  tenantId: string,
+): Promise<boolean> {
   try {
-    // Check if user has admin role in the tenant
     const userRole = await getUserTenantRole(requestedBy, tenantId);
-    const adminRoles = ['admin', 'owner', 'compliance_officer'];
-    
-    if (!adminRoles.includes(userRole)) {
-      logger.warn('Insufficient permissions for DSR operation', {
+    const adminRoles = ["admin", "owner", "compliance_officer"];
+
+    if (!userRole || !adminRoles.includes(userRole)) {
+      logger.warn("Insufficient permissions for DSR operation", {
         requestedBy,
         tenantId,
-        userRole,
-        requiredRoles: adminRoles
+        userRole: userRole || "unknown",
+        requiredRoles: adminRoles,
       });
       return false;
     }
-    
+
     return true;
   } catch (error) {
-    logger.error('Admin permission verification failed', { requestedBy, tenantId, error });
+    logger.error("Admin permission verification failed", {
+      requestedBy,
+      tenantId,
+      error,
+    });
     return false;
   }
 }
 
-async function getUserTenantRole(userId: string, tenantId: string): Promise<string> {
-  // Implementation would query user roles from database
-  // This is a simplified implementation
+export async function getUserTenantRole(
+  userId: string,
+  tenantId: string,
+): Promise<string | null> {
   try {
-    // Mock role checking - in production would query database
-    const isAdmin = userId.includes('admin') || userId.includes('owner');
-    return isAdmin ? 'admin' : 'user';
+    return await withTenantContext(tenantId, async (client) => {
+      const user = await client.user.findUnique({ where: { id: userId } });
+      if (!user || !Array.isArray(user.roles)) {
+        return null;
+      }
+      const [primaryRole] = user.roles as unknown as string[];
+      return primaryRole || null;
+    });
   } catch (error) {
-    logger.error('Failed to get user tenant role', { userId, tenantId, error });
-    return 'user';
+    logger.error("Failed to get user tenant role", { userId, tenantId, error });
+    return null;
   }
 }
 

--- a/tests/dsr/permissions.test.ts
+++ b/tests/dsr/permissions.test.ts
@@ -1,0 +1,75 @@
+import { jest } from "@jest/globals";
+
+// Mock database client before importing module under test
+jest.mock("../../services/shared/database/client", () => ({
+  withTenantContext: jest.fn(),
+}));
+
+// Mock heavy dependencies to avoid requiring external services
+jest.mock("../../services/dsr/src/data-subject-rights-service", () => ({
+  DataSubjectRightsService: class {},
+  DSRRequest: class {},
+}));
+
+import * as dsrApi from "../../services/dsr/src/dsr-api";
+import { withTenantContext } from "../../services/shared/database/client";
+
+describe("verifyAdminPermission", () => {
+  afterEach(() => {
+    (withTenantContext as jest.Mock).mockReset();
+  });
+
+  it("allows admin roles", async () => {
+    (withTenantContext as jest.Mock).mockImplementation(async (_t, fn) => {
+      return fn({
+        user: { findUnique: jest.fn().mockResolvedValue({ roles: ["admin"] }) },
+      });
+    });
+    const result = await dsrApi.verifyAdminPermission("user1", "tenant1");
+    expect(result).toBe(true);
+  });
+
+  it("denies non-admin roles", async () => {
+    (withTenantContext as jest.Mock).mockImplementation(async (_t, fn) => {
+      return fn({
+        user: { findUnique: jest.fn().mockResolvedValue({ roles: ["user"] }) },
+      });
+    });
+    const result = await dsrApi.verifyAdminPermission("user2", "tenant1");
+    expect(result).toBe(false);
+  });
+
+  it("denies when role data is missing", async () => {
+    (withTenantContext as jest.Mock).mockImplementation(async (_t, fn) => {
+      return fn({ user: { findUnique: jest.fn().mockResolvedValue(null) } });
+    });
+    const result = await dsrApi.verifyAdminPermission("user3", "tenant1");
+    expect(result).toBe(false);
+  });
+});
+
+// Tests for getUserTenantRole mocking database access
+
+describe("getUserTenantRole", () => {
+  afterEach(() => {
+    (withTenantContext as jest.Mock).mockReset();
+  });
+
+  it("returns role from database record", async () => {
+    (withTenantContext as jest.Mock).mockImplementation(async (_t, fn) => {
+      return fn({
+        user: { findUnique: jest.fn().mockResolvedValue({ roles: ["admin"] }) },
+      });
+    });
+    const role = await dsrApi.getUserTenantRole("user1", "tenant1");
+    expect(role).toBe("admin");
+  });
+
+  it("returns null when user not found", async () => {
+    (withTenantContext as jest.Mock).mockImplementation(async (_t, fn) => {
+      return fn({ user: { findUnique: jest.fn().mockResolvedValue(null) } });
+    });
+    const role = await dsrApi.getUserTenantRole("userMissing", "tenant1");
+    expect(role).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Fetch user roles from database for DSR operations
- Harden admin permission verification with missing data handling
- Add unit tests for role-based permission checks

## Testing
- `npx jest tests/dsr/permissions.test.ts`
- `make test` *(fails: @smm-architect/ui build missing)*
- `make test-security` *(fails: RLS policy requirements not met)*

------
https://chatgpt.com/codex/tasks/task_e_68b9731d65e4832b9800b193e83151d4
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Replaced mock role checks with real tenant role lookups for DSR admin verification, ensuring only authorized users can perform scope-level deletions. Added tests and safer handling when role data is missing.

- **Bug Fixes**
  - Admin checks now read user.roles from the database via withTenantContext; only admin, owner, or compliance_officer are allowed.
  - Denies and logs when the user is missing or roles are absent.
  - Exported verifyAdminPermission and getUserTenantRole for reuse and testing.
  - Added unit tests for allowed, denied, and missing-role cases.

<!-- End of auto-generated description by cubic. -->

