### PR TITLE
Enforce real OpenAI/Pinecone credentials and add vector service tests

### DIFF
--- a/services/toolhub/tests/setup.ts
+++ b/services/toolhub/tests/setup.ts
@@ -40,6 +40,10 @@ process.env.VAULT_URL = 'http://localhost:8200';
 process.env.SIMULATOR_SERVICE_URL = 'http://localhost:8082';
 process.env.RENDER_SERVICE_URL = 'http://localhost:8083';
 process.env.BASE_URL = 'http://localhost:8080';
+process.env.OPENAI_API_KEY = 'test-openai-key';
+process.env.PINECONE_API_KEY = 'test-pinecone-key';
+process.env.PINECONE_ENVIRONMENT = 'test-env';
+process.env.PINECONE_INDEX = 'test-index';
 
 // Mock console methods for cleaner test output
 global.console = {

--- a/services/toolhub/tests/vector-service.test.ts
+++ b/services/toolhub/tests/vector-service.test.ts
@@ -1,0 +1,116 @@
+import axios from 'axios';
+import { VectorService } from '../src/services/vector-service';
+import { ApiError } from '../src/middleware/error-handler';
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('VectorService', () => {
+  beforeEach(() => {
+    mockedAxios.post.mockReset();
+  });
+
+  describe('constructor', () => {
+    it('throws if credentials are missing', () => {
+      const openai = process.env.OPENAI_API_KEY;
+      const pinecone = process.env.PINECONE_API_KEY;
+      const env = process.env.PINECONE_ENVIRONMENT;
+      const index = process.env.PINECONE_INDEX;
+      delete process.env.OPENAI_API_KEY;
+      delete process.env.PINECONE_API_KEY;
+      delete process.env.PINECONE_ENVIRONMENT;
+      delete process.env.PINECONE_INDEX;
+      expect(() => new VectorService()).toThrow('OPENAI_API_KEY is required');
+      process.env.OPENAI_API_KEY = openai;
+      process.env.PINECONE_API_KEY = pinecone;
+      process.env.PINECONE_ENVIRONMENT = env;
+      process.env.PINECONE_INDEX = index;
+    });
+  });
+
+  describe('generateEmbedding', () => {
+    it('returns embedding on success', async () => {
+      mockedAxios.post.mockResolvedValueOnce({ data: { data: [{ embedding: [0.1, 0.2] }] } });
+      const service = new VectorService();
+      const result = await service.generateEmbedding('hello world');
+      expect(result).toEqual([0.1, 0.2]);
+    });
+
+    it('throws ApiError on failure', async () => {
+      mockedAxios.post.mockRejectedValueOnce(new Error('OpenAI failure'));
+      const service = new VectorService();
+      await expect(service.generateEmbedding('text')).rejects.toBeInstanceOf(ApiError);
+    });
+  });
+
+  describe('upsertVectors', () => {
+    const docs = [
+      {
+        id: '1',
+        workspaceId: 'ws',
+        content: 'content',
+        metadata: { contentType: 'webpage' },
+        embedding: [0.1],
+        createdAt: 'now',
+        updatedAt: 'now'
+      }
+    ];
+
+    it('calls pinecone upsert', async () => {
+      mockedAxios.post.mockResolvedValueOnce({ data: {} });
+      const service = new VectorService();
+      await service.upsertVectors(docs as any);
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        expect.stringContaining('/vectors/upsert'),
+        expect.any(Object),
+        expect.any(Object)
+      );
+    });
+
+    it('throws ApiError on failure', async () => {
+      mockedAxios.post.mockRejectedValueOnce(new Error('Pinecone upsert error'));
+      const service = new VectorService();
+      await expect(service.upsertVectors(docs as any)).rejects.toBeInstanceOf(ApiError);
+    });
+  });
+
+  describe('searchSimilar', () => {
+    it('returns results from pinecone', async () => {
+      mockedAxios.post
+        .mockResolvedValueOnce({ data: { data: [{ embedding: [0.1, 0.2] }] } })
+        .mockResolvedValueOnce({
+          data: {
+            matches: [
+              {
+                id: 'doc1',
+                score: 0.9,
+                metadata: {
+                  content: 'content',
+                  contentType: 'webpage',
+                  sourceUrl: 'url',
+                  title: 'Title',
+                  author: 'Author',
+                  publishedAt: 'now',
+                  tags: ['tag'],
+                  sourceId: 'src1'
+                }
+              }
+            ]
+          }
+        });
+      const service = new VectorService();
+      const results = await service.searchSimilar({ workspaceId: 'ws', query: 'q' });
+      expect(results[0]).toMatchObject({ id: 'doc1', score: 0.9 });
+      expect(mockedAxios.post).toHaveBeenCalledTimes(2);
+    });
+
+    it('throws ApiError when query fails', async () => {
+      mockedAxios.post
+        .mockResolvedValueOnce({ data: { data: [{ embedding: [0.1] }] } })
+        .mockRejectedValueOnce(new Error('Pinecone query error'));
+      const service = new VectorService();
+      await expect(
+        service.searchSimilar({ workspaceId: 'ws', query: 'q' })
+      ).rejects.toBeInstanceOf(ApiError);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Fail fast when OPENAI or Pinecone credentials are missing
- Use real embedding generation and Pinecone operations in vector service
- Add unit tests for embeddings, upsert and search (success & error paths)

## Testing
- `npx jest tests/vector-service.test.ts --config jest.config.json`
- `npx jest --config jest.config.json` *(fails: expected 400s return 403s in integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b9730dffc8832bad3ab5d826f3d23f
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Require real OpenAI and Pinecone credentials and remove mock modes in the vector service. All vector operations now hit real APIs, with unit tests covering success and error paths.

- **Refactors**
  - Throw if OPENAI_API_KEY, PINECONE_API_KEY, PINECONE_ENVIRONMENT, or PINECONE_INDEX are missing.
  - Remove mock embedding/upsert/search/delete/stats paths; use real OpenAI and Pinecone endpoints.
  - Add unit tests for generateEmbedding, upsertVectors, and searchSimilar with axios mocks.

- **Migration**
  - Set these env vars in local and CI: OPENAI_API_KEY, PINECONE_API_KEY, PINECONE_ENVIRONMENT, PINECONE_INDEX.

<!-- End of auto-generated description by cubic. -->

