### PR TITLE
feat(auth): connect registration and token refresh to database

### DIFF
--- a/services/shared/database/schema.prisma
+++ b/services/shared/database/schema.prisma
@@ -328,6 +328,7 @@ model AgentRun {
 model User {
   id            String   @id @default(cuid())
   email         String   @unique
+  passwordHash  String   @map("password_hash")
   name          String?
   tenantId      String   @map("tenant_id")
   roles         Json     @default("[]")

--- a/services/smm-architect/package.json
+++ b/services/smm-architect/package.json
@@ -10,40 +10,40 @@
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "test:performance": "jest --testPathPattern=performance --runInBand --detectOpenHandles",
-    "test:schema": "jest --testPathPattern=schema",
+    "test:schema": "jest --testNamePattern='schema' --timeout=60000",
     "benchmark": "npm run test:performance -- --verbose --outputFile=jest-performance-results.json",
     "test:contract": "jest --testNamePattern='pact' --runInBand",
     "test:model-evaluation": "jest --testNamePattern='model-evaluation' --timeout=300000",
     "test:drift-detection": "jest --testNamePattern='drift-detection' --timeout=120000",
     "test:security": "jest --testNamePattern='security' --timeout=180000",
-    "test:schema": "jest --testNamePattern='schema' --timeout=60000",
     "lint": "eslint src/**/*.ts",
     "lint:fix": "eslint src/**/*.ts --fix",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "encore.dev": "^1.0.0",
     "@google-cloud/kms": "^4.0.0",
-    "node-vault": "^0.10.0",
-    "ajv": "^8.12.0",
-    "winston": "^3.11.0",
-    "uuid": "^9.0.0",
-    "date-fns": "^2.30.0",
     "@sentry/node": "^7.99.0",
-    "@sentry/profiling-node": "^7.99.0"
+    "@sentry/profiling-node": "^7.99.0",
+    "ajv": "^8.12.0",
+    "bcryptjs": "^2.4.3",
+    "date-fns": "^2.30.0",
+    "encore.dev": "^1.0.0",
+    "node-vault": "^0.10.0",
+    "uuid": "^9.0.0",
+    "winston": "^3.11.0"
   },
   "devDependencies": {
+    "@types/bcryptjs": "^2.4.6",
+    "@types/jest": "^29.5.0",
     "@types/node": "^20.0.0",
     "@types/uuid": "^9.0.0",
-    "@types/jest": "^29.5.0",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
     "eslint": "^8.50.0",
     "jest": "^29.7.0",
+    "nock": "^13.3.3",
     "ts-jest": "^29.1.0",
-    "typescript": "^5.2.0",
-
-    "nock": "^13.3.3"
+    "typescript": "^5.2.0"
   },
   "keywords": [
     "smm",

--- a/tests/auth/registration-refresh.test.ts
+++ b/tests/auth/registration-refresh.test.ts
@@ -1,0 +1,54 @@
+const TEST_DB_URL = 'postgresql://postgres:postgres@localhost:5432/smm_architect_test';
+const TENANT_ID = 'test-tenant';
+
+process.env.DATABASE_URL = TEST_DB_URL;
+process.env.JWT_SECRET = 'ThisIsAHighlySecureSecretKeyWithSufficientLength123!';
+
+const authApi = require('../../services/smm-architect/src/auth-api');
+const { withTenantContext } = require('../../services/shared/database/client');
+const { register, refresh } = authApi;
+
+beforeEach(async () => {
+  await withTenantContext(TENANT_ID, async (client: any) => {
+    await client.userSession.deleteMany({});
+    await client.user.deleteMany({});
+  });
+});
+
+describe('Registration and token refresh', () => {
+  it('registers user with hashed password', async () => {
+    await register({
+      email: 'test@example.com',
+      password: 'StrongPass1',
+      name: 'Test User',
+      tenantId: TENANT_ID
+    });
+
+    const user = await withTenantContext(TENANT_ID, (client: any) =>
+      client.user.findUnique({ where: { email: 'test@example.com' } })
+    );
+
+    expect(user).toBeDefined();
+    expect(user?.passwordHash).toBeDefined();
+    expect(user?.passwordHash).not.toBe('StrongPass1');
+  });
+
+  it('refreshes token and revokes old refresh token', async () => {
+    const { id: userId } = await (authApi as any).createUserAccount({
+      email: 'refresh@example.com',
+      password: 'StrongPass1',
+      name: 'Refresh User',
+      tenantId: TENANT_ID
+    });
+
+    const oldToken = await (authApi as any).generateRefreshToken(userId, TENANT_ID);
+    const response = await refresh({ refreshToken: oldToken });
+
+    expect(response.refreshToken).toBeDefined();
+    expect(response.refreshToken).not.toBe(oldToken);
+
+    const oldValidation = await (authApi as any).validateRefreshToken(oldToken);
+    expect(oldValidation).toBeNull();
+  });
+});
+


### PR DESCRIPTION
## Summary
- hash user passwords and persist accounts via Prisma
- store and revoke refresh tokens in user sessions
- add tests covering registration and token refresh flows

## Testing
- `make test` *(fails: turbo not found)*
- `make test-security` *(fails: RLS violations in migrations)*

------
https://chatgpt.com/codex/tasks/task_e_68b9730238e8832bb093a9211f8dbc49