### PR TITLE
feat: integrate Vault and auth services for agents

### DIFF
--- a/services/agents/package.json
+++ b/services/agents/package.json
@@ -24,6 +24,7 @@
     "lodash": "^4.17.21",
     "node-cron": "^3.0.3",
     "node-vault": "^0.10.0",
+    "jsonwebtoken": "^9.0.0",
     "uuid": "^9.0.0",
     "winston": "^3.11.0"
   },
@@ -40,6 +41,7 @@
     "eslint": "^8.50.0",
     "jest": "^29.7.0",
     "nodemon": "^3.0.0",
+    "nock": "^14.0.0",
     "supertest": "^6.3.0",
     "ts-jest": "^29.1.0",
     "ts-node": "^10.9.0",

--- a/services/agents/tests/setup.ts
+++ b/services/agents/tests/setup.ts
@@ -1,0 +1,7 @@
+import nock from 'nock';
+
+nock.disableNetConnect();
+
+afterEach(() => {
+  nock.cleanAll();
+});

--- a/services/agents/tests/vault-token-issuer.test.ts
+++ b/services/agents/tests/vault-token-issuer.test.ts
@@ -1,0 +1,69 @@
+import nock from 'nock';
+import { VaultTokenIssuer } from '../src/vault-token-issuer';
+
+describe('VaultTokenIssuer', () => {
+  const vaultUrl = 'http://localhost:8200';
+  const vaultToken = 'root-token';
+  let issuer: VaultTokenIssuer;
+
+  beforeEach(() => {
+    process.env.VAULT_ADDR = vaultUrl;
+    process.env.VAULT_TOKEN = vaultToken;
+    process.env.AUTH_JWT_SECRET = 'test-secret';
+    process.env.AUTH_JWT_ISSUER = 'test-issuer';
+    process.env.AUTH_JWT_AUDIENCE = 'test-audience';
+    issuer = new VaultTokenIssuer({ endpoint: vaultUrl, token: vaultToken });
+  });
+
+  afterEach(() => {
+    delete process.env.VAULT_ADDR;
+    delete process.env.VAULT_TOKEN;
+    delete process.env.AUTH_JWT_SECRET;
+    delete process.env.AUTH_JWT_ISSUER;
+    delete process.env.AUTH_JWT_AUDIENCE;
+    nock.cleanAll();
+  });
+
+  it('issues an agent token', async () => {
+    nock(vaultUrl)
+      .post('/v1/auth/token/create')
+      .reply(200, {
+        auth: {
+          client_token: 'agent-token',
+          policies: ['default'],
+          lease_duration: 7200,
+          renewable: false
+        }
+      });
+
+    const token = await issuer.issueAgentToken('research', 'ws1');
+    expect(token).toBe('agent-token');
+  });
+
+  it('revokes a token', async () => {
+    nock(vaultUrl)
+      .post('/v1/auth/token/revoke', { token: 'hvs.agent-token' })
+      .reply(200, {});
+
+    await issuer.revokeToken('hvs.agent-token');
+    expect(nock.isDone()).toBe(true);
+  });
+
+  it('looks up a token', async () => {
+    nock(vaultUrl)
+      .post('/v1/auth/token/lookup', { token: 'agent-token' })
+      .reply(200, {
+        data: {
+          meta: { agent_type: 'research', workspace_id: 'ws1' },
+          policies: ['default'],
+          ttl: 3600,
+          renewable: false
+        }
+      });
+
+    const info = await issuer.lookupToken('agent-token');
+    expect(info.agentType).toBe('research');
+    expect(info.workspaceId).toBe('ws1');
+    expect(info.policies).toContain('default');
+  });
+});


### PR DESCRIPTION
## Summary
- replace mocks with real Vault and auth service adapters
- parameterize Vault and auth config via environment variables
- add unit tests for token issuance, revocation, and lookup with mocked HTTP calls

## Testing
- `npm test tests/vault-token-issuer.test.ts`
- `npm test` *(fails: executor integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b972d7c274832b8974bed90a7a14aa
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Integrated real Vault and auth service adapters for agents, replacing mocks. Adds env-based configuration and unit tests for token issuance, revocation, and lookup.

- **New Features**
  - Swapped mocks for shared VaultClient and AuthenticationService; added initialize() in VaultTokenIssuer.
  - Agent now uses VaultClient and initializes it once before secret reads.
  - Config via env vars for Vault and auth JWT settings.
  - Unit tests with nock for create/revoke/lookup; added test setup to block real HTTP.
  - Added dependencies: jsonwebtoken, nock.

- **Migration**
  - Set env vars: VAULT_ADDR, VAULT_TOKEN, (optional) VAULT_NAMESPACE, AUTH_JWT_SECRET, AUTH_JWT_ISSUER, AUTH_JWT_AUDIENCE.

<!-- End of auto-generated description by cubic. -->

