### PR TITLE
feat(frontend): secure locale cookie

### DIFF
--- a/apps/frontend/src/middleware.ts
+++ b/apps/frontend/src/middleware.ts
@@ -64,7 +64,8 @@ export async function middleware(request: NextRequest) {
       maxAge: 365 * 24 * 60 * 60, // 1 year
       path: '/',
       secure: process.env.NODE_ENV === 'production',
-      sameSite: 'lax'
+      sameSite: 'lax',
+      httpOnly: true
     })
     
     return response


### PR DESCRIPTION
## Summary
- set frontend locale cookie as httpOnly to improve security

## Testing
- `make test` (fails: turbo not found)
- `make test-security` (fails: 54 RLS policy violations)


------
https://chatgpt.com/codex/tasks/task_e_68b97d5e959c832baad47ed542ba6c82